### PR TITLE
Skills fix

### DIFF
--- a/charactersheet/charactersheet/models/spell.js
+++ b/charactersheet/charactersheet/models/spell.js
@@ -35,7 +35,7 @@ function Spell() {
     self.spellDamageLabel = ko.pureComputed(function() {
         var charKey = CharacterManager.activeCharacter().key();
 
-        if( self.spellType() === 'Attack' ){
+        if( self.spellType() === 'Attack Roll' ){
             var spellBonus = SpellStats.findBy(charKey)[0] ? SpellStats.findBy(charKey)[0].spellAttackBonus() : 0;
             return (self.spellDmg() + ' [Spell Bonus: +' + spellBonus + ']');
         }

--- a/charactersheet/charactersheet/templates/saving_throws.tmpl.html
+++ b/charactersheet/charactersheet/templates/saving_throws.tmpl.html
@@ -101,17 +101,12 @@
 
     <!-- ViewEdit Modal -->
     <div data-bind="with: selecteditem">
-    <div class="modal fade"
-         id="viewSavingThrow"
-         tabindex="-1"
-         role="dialog"
+    <div class="modal fade" id="viewSavingThrow" tabindex="-1" role="dialog"
          aria-labelledby="viewSavingThrowLabel">
       <div class="modal-dialog" role="document">
         <div class="modal-content">
           <div class="modal-header">
-            <button type="button"
-                    class="close"
-                    data-dismiss="modal"
+            <button type="button" class="close" data-dismiss="modal"
                     aria-label="Close">
               <span aria-hidden="true">&times;</span>
             </button>
@@ -168,4 +163,3 @@
       </div> <!-- Modal Dialog -->
     </div> <!-- Modal Fade -->
     </div> <!-- End with statement -->
-</div> <!-- Panel -->

--- a/charactersheet/charactersheet/templates/skills.tmpl.html
+++ b/charactersheet/charactersheet/templates/skills.tmpl.html
@@ -28,7 +28,8 @@
         </tr>
       </tbody>
     </table>
-    </div>
+  </div> <!-- Panel Body -->
+</div> <!-- Panel -->
     <!-- ViewEdit Modal -->
     <div data-bind="with: selecteditem">
     <div class="modal fade" id="viewSkill" tabindex="-1" role="dialog"
@@ -36,15 +37,15 @@
       <div class="modal-dialog" role="document">
         <div class="modal-content">
           <div class="modal-header">
-            <button type="button" class="close" data-dismiss="modal"
+            <a type="button" class="close" data-dismiss="modal"
                     aria-label="Close">
               <span aria-hidden="true">&times;</span>
-            </button>
+            </a>
             <h4 class="modal-title" id="addSkillLabel"
               data-bind="text: name"></h4>
-        </div>
+          </div>
           <div class="modal-body">
-            <form class="form-horizontal">
+            <form class="form-horizontal" onsubmit="return false">
               <div class="form-group">
                 <label for="modifier" class="col-sm-2 control-label">
                   Modifier
@@ -69,16 +70,14 @@
                            data-bind="checked: proficiency">
                   </div>
               </div>
-              </div>
+              </div><!-- Modal Body -->
               <div class="modal-footer">
                 <button type="button"
                         class="btn btn-primary"
                         data-dismiss="modal">Done</button>
-              </div>
+              </div> <!-- Modal Footer -->
             </form>
-          </div> <!-- Modal Body -->
-        </div> <!-- Modal Content -->
-      </div> <!-- Modal Dialog -->
-    </div> <!-- Modal Fade -->
+          </div> <!-- Modal Content -->
+        </div> <!-- Modal Dialog -->
+      </div> <!-- Modal Fade -->
     </div> <!-- End with statement -->
-</div> <!-- Panel -->

--- a/charactersheet/charactersheet/templates/skills.tmpl.html
+++ b/charactersheet/charactersheet/templates/skills.tmpl.html
@@ -37,10 +37,10 @@
       <div class="modal-dialog" role="document">
         <div class="modal-content">
           <div class="modal-header">
-            <a type="button" class="close" data-dismiss="modal"
+            <button type="button" class="close" data-dismiss="modal"
                     aria-label="Close">
               <span aria-hidden="true">&times;</span>
-            </a>
+            </button>
             <h4 class="modal-title" id="addSkillLabel"
               data-bind="text: name"></h4>
           </div>

--- a/test/models/test_spell.js
+++ b/test/models/test_spell.js
@@ -73,7 +73,7 @@ describe('Spell Model', function() {
             });
 
             var ft = new Spell();
-            ft.spellType('Attack');
+            ft.spellType('Attack Roll');
             ft.spellDmg('1D4');
             ft.spellDamageLabel().should.equal('1D4 [Spell Bonus: +3]');
 


### PR DESCRIPTION
### Summary of Changes
Prevented page from refreshing due to enter key pressed


### Issues Fixed
Fixes #771 


### Changes Proposed (if any)
Apparently, browsers submit modals that have only __one__ input field on enter key press. Changed form attribute to not submit on enter key press.

