### PR TITLE
Fix short rest message

### DIFF
--- a/charactersheet/charactersheet/utilities/fixtures.js
+++ b/charactersheet/charactersheet/utilities/fixtures.js
@@ -84,7 +84,7 @@ Fixtures = {
             'Bludgeoning', 'Piercing', 'Slashing']
     },
     resting : {
-        shortRestMessage : 'Your spell slots and daily features have been restored.',
+        shortRestMessage : 'Your daily features have been restored.',
         longRestMessage : 'Your hit dice, spell slots, hit points, ' +
             'and daily features have been restored.'
     }


### PR DESCRIPTION
### Summary of Changes

Fixed short rest message to display accurate message, i.e. what exactly was altered after the short rest.

### Issues Fixed

#757

### Screen Shot of Proposed Changes (if UI related)

<img width="1236" alt="screen shot 2016-09-09 at 6 33 39 am" src="https://cloud.githubusercontent.com/assets/5814150/18388745/b080f6b8-7657-11e6-91d8-83e7fcb30ab0.png">


