### PR TITLE
Adds Bootstrap Binding for Wells.

### DIFF
--- a/charactersheet/bin/knockout-boostrap-collapse.js
+++ b/charactersheet/bin/knockout-boostrap-collapse.js
@@ -1,0 +1,45 @@
+'use strict';
+
+/**
+ * Knockout Bootstrap Well Binding
+ * author: Brian Schrader
+ *
+ * Open and close a bootstrap well using an observable.
+ * This binding also has an optional field for a callback
+ * once the animation has completed.
+ *
+ * Note: The callback is called when the well is both opened and closed.
+ *
+ * Usage:
+ * <div data-bind="well: { open: myObservable, callback: myFunction }"></div>
+ */
+ko.bindingHandlers.well = {
+    init: function(element, valueAccessor, allBindingsAccessor) {
+        var value = valueAccessor();
+        var openOrClosed = ko.utils.unwrapObservable(value.open);
+        var callback = ko.utils.unwrapObservable(value.callback);
+
+        $(element).collapse({
+            toggle: false
+        });
+
+        if (callback) {
+            // Register callbacks.
+            $(element).on('hidden.bs.collapse', callback);
+            $(element).on('shown.bs.collapse', callback);
+        }
+
+        ko.bindingHandlers.well.toggle(openOrClosed, element);
+    },
+
+    update: function(element, valueAccessor) {
+        var value = valueAccessor();
+        var openOrClosed = ko.utils.unwrapObservable(value.open);
+        ko.bindingHandlers.well.toggle(openOrClosed, element);
+    },
+
+    toggle: function(openOrClosed, element) {
+        var action = openOrClosed ? 'show' : 'hide';
+        $(element).collapse(action);
+    }
+};

--- a/charactersheet/charactersheet/index.html
+++ b/charactersheet/charactersheet/index.html
@@ -490,6 +490,7 @@
 <script src="/bin/tooltip_bind.js" type="text/javascript"></script>
 <script src="/bin/select2.js" type="text/javascript"></script>
 <script src="/bin/knockout-binding-contenteditable.js" type="text/javascript"></script>
+<script src="/bin/knockout-boostrap-collapse.js" type="text/javascript"></script>
 <!-- ViewModels -->
 <script src="viewmodels/actions_toolbar.js" type="text/javascript"></script>
 <script src="viewmodels/ability_scores.js" type="text/javascript"></script>

--- a/charactersheet/charactersheet/templates/actions_toolbar.tmpl.html
+++ b/charactersheet/charactersheet/templates/actions_toolbar.tmpl.html
@@ -1,4 +1,4 @@
-<div class="collapse" id="actionsCollapse">
+<div class="collapse" data-bind="well: { open: wellOpen }">
   <div class="well well-no-padding well-top-shadow">
     <div class="row">
       <div class="col-sm-offset-3 col-sm-6">


### PR DESCRIPTION
### Summary of Changes

Adds a binding for bootstrap wells.
- The binding requires an observable which determines whether or not the well is open
- The binding also has an optional callback parameter which is called when the open/close animation has finished.

The Actions Toolbar now uses this binding.

### Issues Fixed

None logged. Precursor for #602 