### PR TITLE
Adds HotKey for Toggling the Actions Toolbar

### DIFF
--- a/charactersheet/bin/knockout-boostrap-collapse.js
+++ b/charactersheet/bin/knockout-boostrap-collapse.js
@@ -1,0 +1,45 @@
+'use strict';
+
+/**
+ * Knockout Bootstrap Well Binding
+ * author: Brian Schrader
+ *
+ * Open and close a bootstrap well using an observable.
+ * This binding also has an optional field for a callback
+ * once the animation has completed.
+ *
+ * Note: The callback is called when the well is both opened and closed.
+ *
+ * Usage:
+ * <div data-bind="well: { open: myObservable, callback: myFunction }"></div>
+ */
+ko.bindingHandlers.well = {
+    init: function(element, valueAccessor, allBindingsAccessor) {
+        var value = valueAccessor();
+        var openOrClosed = ko.utils.unwrapObservable(value.open);
+        var callback = ko.utils.unwrapObservable(value.callback);
+
+        $(element).collapse({
+            toggle: false
+        });
+
+        if (callback) {
+            // Register callbacks.
+            $(element).on('hidden.bs.collapse', callback);
+            $(element).on('shown.bs.collapse', callback);
+        }
+
+        ko.bindingHandlers.well.toggle(openOrClosed, element);
+    },
+
+    update: function(element, valueAccessor) {
+        var value = valueAccessor();
+        var openOrClosed = ko.utils.unwrapObservable(value.open);
+        ko.bindingHandlers.well.toggle(openOrClosed, element);
+    },
+
+    toggle: function(openOrClosed, element) {
+        var action = openOrClosed ? 'show' : 'hide';
+        $(element).collapse(action);
+    }
+};

--- a/charactersheet/charactersheet/index.html
+++ b/charactersheet/charactersheet/index.html
@@ -490,6 +490,7 @@
 <script src="/bin/tooltip_bind.js" type="text/javascript"></script>
 <script src="/bin/select2.js" type="text/javascript"></script>
 <script src="/bin/knockout-binding-contenteditable.js" type="text/javascript"></script>
+<script src="/bin/knockout-boostrap-collapse.js" type="text/javascript"></script>
 <!-- ViewModels -->
 <script src="viewmodels/actions_toolbar.js" type="text/javascript"></script>
 <script src="viewmodels/ability_scores.js" type="text/javascript"></script>

--- a/charactersheet/charactersheet/templates/actions_toolbar.tmpl.html
+++ b/charactersheet/charactersheet/templates/actions_toolbar.tmpl.html
@@ -1,4 +1,4 @@
-<div class="collapse" id="actionsCollapse">
+<div class="collapse" data-bind="well: { open: wellOpen }">
   <div class="well well-no-padding well-top-shadow">
     <div class="row">
       <div class="col-sm-offset-3 col-sm-6">

--- a/charactersheet/charactersheet/utilities/notifications.js
+++ b/charactersheet/charactersheet/utilities/notifications.js
@@ -87,6 +87,10 @@ var Notifications = {
      **** Data Changed Events ****
      *****************************/
 
+    actionsToolbar: {
+        toggle: new signals.Signal()
+    },
+
     abilityScores: {
         changed: new signals.Signal()
     },

--- a/charactersheet/charactersheet/viewmodels/actions_toolbar.js
+++ b/charactersheet/charactersheet/viewmodels/actions_toolbar.js
@@ -5,7 +5,9 @@ function ActionsToolbarViewModel() {
 
     self.wellOpen = ko.observable(false);
 
-    self.init = function() {};
+    self.init = function() {
+        Notifications.actionsToolbar.shouldOpen.add(self.toggleWellOpen);
+    };
 
     self.load = function() {
     };

--- a/charactersheet/charactersheet/viewmodels/actions_toolbar.js
+++ b/charactersheet/charactersheet/viewmodels/actions_toolbar.js
@@ -6,7 +6,7 @@ function ActionsToolbarViewModel() {
     self.wellOpen = ko.observable(false);
 
     self.init = function() {
-        Notifications.actionsToolbar.shouldOpen.add(self.toggleWellOpen);
+        Notifications.actionsToolbar.toggle.add(self.toggleWellOpen);
     };
 
     self.load = function() {

--- a/charactersheet/charactersheet/viewmodels/root.js
+++ b/charactersheet/charactersheet/viewmodels/root.js
@@ -26,7 +26,7 @@ function RootViewModel() {
     self.activeTab = ko.observable();
 
     //Player Child View Models
-    self.actionsToolbarViewModel = ko.observable(new ActionsToolbarViewModel());
+    self.actionsToolbarViewModel   = ko.observable(new ActionsToolbarViewModel());
 
     self.profileTabViewModel       = ko.observable(new ProfileTabViewModel());
     self.statsTabViewModel         = ko.observable(new StatsTabViewModel());
@@ -94,6 +94,9 @@ function RootViewModel() {
     };
     self.activateNotesTab = function() {
         self.activeTab('notes');
+    };
+    self.toggleWell = function() {
+        Notifications.actionsToolbar.toggle.dispatch();
     };
 
     //UI Methods
@@ -165,6 +168,7 @@ function RootViewModel() {
         self.notesTabViewModel().init();
         self.charactersViewModel.init();
         self.userNotificationViewModel.init();
+        self.actionsToolbarViewModel().init();
 
         self.wizardViewModel.init();
 
@@ -204,6 +208,8 @@ function RootViewModel() {
         HotkeysService.registerHotkey('5', self.activateInventoryTab);
         HotkeysService.registerHotkey('6', self.activateNotesTab);
         HotkeysService.registerHotkey('7', self.activateProfileTab);
+        HotkeysService.registerHotkey('8', self.toggleWell);
+
 
         //Once init-ed, we can check for a character to load, if any.
         var character = Character.findAll()[0];
@@ -233,6 +239,7 @@ function RootViewModel() {
                 self.notesTabViewModel().load();
             }
             self.userNotificationViewModel.load();
+            self.actionsToolbarViewModel().load();
             self.charactersViewModel.load();
             self.settingsViewModel().load();
             self._dummy.valueHasMutated();
@@ -254,6 +261,7 @@ function RootViewModel() {
                 self.notesTabViewModel().unload();
             }
             self.userNotificationViewModel.unload();
+            self.actionsToolbarViewModel().unload();
             self.charactersViewModel.unload();
             self.settingsViewModel().unload();
             self.wizardViewModel.unload();


### PR DESCRIPTION
### Summary of Changes

#### Adds a binding for bootstrap wells.
- The binding requires an observable which determines whether or not the well is open
- The binding also has an optional callback parameter which is called when the open/close animation has finished.
- The Actions Toolbar now uses this binding.

#### Adds HotKey for Toggling the Actions Toolbar.
- Fixes an issue where the actions init/load/unload calls were never made.

### Issues Fixed

Fixes #602 

### Notes

Supplants #780 

From the Commit Notes:

> During development there was an issue with activating the toolbar via signals and hotkeys. This was due to the fact that the Actions Toolbar was attempting to set the hotkeys during the load/init process. According to the debug logs it appeared that the call was being made but on a different object than the one used later in the process. 

> The actual issue turned out to be that the Actions Toolbar was appearing to call the load/init functions but wasn't as they were never called in the root.js. I've added the calls to the root.js and it works fine now.