### PR TITLE
Spell slots can now be reset on short rest

### DIFF
--- a/charactersheet/charactersheet/models/spell_slot.js
+++ b/charactersheet/charactersheet/models/spell_slot.js
@@ -10,7 +10,7 @@ function Slot() {
     self.level = ko.observable(1);
     self.maxSpellSlots = ko.observable(1);
     self.usedSpellSlots = ko.observable(0);
-    self.resetsOn = ko.observable()
+    self.resetsOn = ko.observable();
 
     self.color = ko.pureComputed(function() {
         return self.slotColors[self.level()-1];

--- a/charactersheet/charactersheet/models/spell_slot.js
+++ b/charactersheet/charactersheet/models/spell_slot.js
@@ -10,6 +10,7 @@ function Slot() {
     self.level = ko.observable(1);
     self.maxSpellSlots = ko.observable(1);
     self.usedSpellSlots = ko.observable(0);
+    self.resetsOn = ko.observable()
 
     self.color = ko.pureComputed(function() {
         return self.slotColors[self.level()-1];
@@ -38,6 +39,7 @@ function Slot() {
         self.level(values.level);
         self.maxSpellSlots(values.maxSpellSlots);
         self.usedSpellSlots(values.usedSpellSlots);
+        self.resetsOn(values.resetsOn);
     };
 
     self.exportValues = function() {
@@ -45,7 +47,8 @@ function Slot() {
             characterId: self.characterId(),
             level: self.level(),
             maxSpellSlots: self.maxSpellSlots(),
-            usedSpellSlots: self.usedSpellSlots()
+            usedSpellSlots: self.usedSpellSlots(),
+            resetsOn: self.resetsOn()
         };
     };
 
@@ -63,3 +66,9 @@ Slot.findAllBy = function(characterId) {
         return e.characterId() === characterId;
     });
 };
+
+Slot.REST_TYPE = {
+    SHORT_REST: 'short',
+    LONG_REST: 'long'
+};
+

--- a/charactersheet/charactersheet/templates/spell_slots.tmpl.html
+++ b/charactersheet/charactersheet/templates/spell_slots.tmpl.html
@@ -122,6 +122,25 @@
 								<input type="number" class="form-control" id="bonus" min="1" max="4" data-bind="value: maxSpellSlots">
 							</div>
 						</div>
+           <div class="form-group">
+           <label class="col-sm-2 control-label">Resets on...</label>
+             <div class="col-sm-10">
+               <div class="btn-group btn-group-justified" role="group">
+                 <label class="btn btn-default"
+                 data-bind="css: { active: resetsOn() == 'short'}">
+                   <input type="radio" class="hide-block"
+                   name="resetsOnShort" value="short" data-bind="checked: resetsOn"/>
+                   Short Rest
+                 </label>
+                 <label class="btn btn-default"
+                 data-bind="css: { active: resetsOn() != 'short'}">
+                   <input type="radio" class="hide-block"
+                   name="resetsOnLong" value="long" data-bind="checked: resetsOn"/>
+                   Long Rest
+                 </label>
+               </div>
+             </div>
+           </div>
 					</div>
 					<div class="modal-footer">
 						<button type="button" class="btn btn-primary" data-dismiss="modal">Done</button>

--- a/charactersheet/charactersheet/templates/spell_slots.tmpl.html
+++ b/charactersheet/charactersheet/templates/spell_slots.tmpl.html
@@ -84,6 +84,27 @@
 							<input type="number" class="form-control" id="max" min="1" max="4" data-bind='textInput: blankSlot().maxSpellSlots'>
 						</div>
 					</div>
+          <div class="form-group">
+            <label class="col-sm-2 control-label">Resets on...</label>
+            <div class="col-sm-10">
+              <div class="btn-group btn-group-justified" role="group">
+                <label class="btn btn-default"
+                 data-bind="css: { active: blankSlot().resetsOn() == 'short'}">
+                   <input type="radio" class="hide-block"
+                   name="blankresetsOnShort" value="short"
+                   data-bind="checked: blankSlot().resetsOn"/>
+                   Short Rest
+                </label>
+                <label class="btn btn-default"
+                 data-bind="css: { active: blankSlot().resetsOn() != 'short'}">
+                   <input type="radio" class="hide-block"
+                   name="blankresetsOnLong" value="long"
+                   data-bind="checked: blankSlot().resetsOn"/>
+                   Long Rest
+                </label>
+              </div>
+            </div>
+          </div>
 					<div class="modal-footer">
 						<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button> <button type="button" class="btn btn-primary" data-bind='click: addSlot' data-dismiss="modal">Add</button>
 					</div>

--- a/charactersheet/charactersheet/utilities/fixtures.js
+++ b/charactersheet/charactersheet/utilities/fixtures.js
@@ -84,7 +84,7 @@ Fixtures = {
             'Bludgeoning', 'Piercing', 'Slashing']
     },
     resting : {
-        shortRestMessage : 'Your daily features have been restored.',
+        shortRestMessage : 'Your daily features, and relevant spell slots have been restored.',
         longRestMessage : 'Your hit dice, spell slots, hit points, ' +
             'and daily features have been restored.'
     }

--- a/charactersheet/charactersheet/viewmodels/spell_slots.js
+++ b/charactersheet/charactersheet/viewmodels/spell_slots.js
@@ -35,6 +35,7 @@ function SpellSlotsViewModel() {
 
         //Notifications
         Notifications.events.longRest.add(self.resetOnLongRest);
+        Notifications.events.shortRest.add(self.resetShortRest);
     };
 
     self.unload = function() {
@@ -68,6 +69,8 @@ function SpellSlotsViewModel() {
             columnName, self.sorts));
     };
 
+    //Manipulating slots
+
     /**
      * Resets all slots on a long-rest.
      */
@@ -77,8 +80,19 @@ function SpellSlotsViewModel() {
         });
     };
 
+    /**
+     * Resets all short-rest slot.
+     */
+    self.resetShortRest = function() {
+        ko.utils.arrayForEach(self.slots(), function(slot) {
+            if (slot.resetsOn() === Slot.REST_TYPE.SHORT_REST) {
+                slot.usedSpellSlots(0);
+            }
+        });
+    };
 
     //Manipulating spell slots
+
     self.maxSlotWidth = function() {
         return 100 / self.slots().length;
     };


### PR DESCRIPTION
### Summary of Changes

- Adds an option for slots to reset on short rest. 
- Slots default to resetting on long rest.

### Issues Fixed

None logged.

![](https://dl.dropboxusercontent.com/s/bwdy2v2aj9sjvg7/Screenshot%202016-09-11%2018.14.27.png?dl=0)