### PR TITLE
Fixes treasure coin styling on small end of large device size.

### DIFF
--- a/charactersheet/charactersheet/templates/treasure.tmpl.html
+++ b/charactersheet/charactersheet/templates/treasure.tmpl.html
@@ -3,19 +3,17 @@
     <!-- Large devices row-->
     <div class="visible-lg-block">
       <div class="row row-padded">
-        <div class="col-lg-1 text-center">
-        </div>
-        <div class="col-sm-2">
-          <div class="input-group ">
+        <div class="col-sm-2 col-md-offset-1 coin-input">
+          <div class="input-group">
             <span class="input-group-addon no-top-bottom-padding">
               <img src="/images/pp-coin.svg" width="30px" title="Platinum Coins" alt="Platinum Coins"/>
             </span>
-            <input type="number" class="form-control" min="1"
+            <input type="number" class="form-control coin-input" min="1"
               data-bind='value: platinum'/>
           </div>
         </div>
-        <div class="col-sm-2">
-          <div class="input-group ">
+        <div class="col-sm-2 coin-input">
+          <div class="input-group">
             <span class="input-group-addon no-top-bottom-padding">
               <img src="/images/gp-coin.svg" width="30px" title="Gold Coins" alt="Gold Coins"/>
             </span>
@@ -23,34 +21,33 @@
               data-bind='value: gold'/>
           </div>
         </div>
-        <div class="col-sm-2">
+        <div class="col-sm-2 coin-input">
           <div class="input-group ">
             <span class="input-group-addon no-top-bottom-padding">
               <img src="/images/ep-coin.svg" width="30px" title="Electrum Coins" alt="Electrum Coins"/>
             </span>
-            <input type="number" class="form-control" min="1"
+            <input type="number" class="form-control coin-input" min="1"
               data-bind='value: electrum'>
           </div>
         </div>
-        <div class="col-sm-2">
+        <div class="col-sm-2 coin-input">
           <div class="input-group ">
             <span class="input-group-addon no-top-bottom-padding">
               <img src="/images/sp-coin.svg" width="30px" title="Silver Coins" alt="Silver Coins"/>
             </span>
-            <input type="number" class="form-control" min="1"
+            <input type="number" class="form-control coin-input" min="1"
               data-bind='value: silver'>
           </div>
         </div>
-        <div class="col-sm-2">
+        <div class="col-sm-2 coin-input">
           <div class="input-group">
             <span class="input-group-addon no-top-bottom-padding">
               <img src="/images/cp-coin.svg" width="30px" title="Copper Coins" alt="Copper Coins"/>
             </span>
-            <input type="number" class="form-control" min="1"
+            <input type="number" class="form-control coin-input" min="1"
               data-bind='value: copper'>
           </div>
         </div>
-        <div class="col-lg-1"></div>
       </div>
     </div><!-- End lg row-->
     <!-- Small/Medium devices row -->

--- a/charactersheet/site.css
+++ b/charactersheet/site.css
@@ -238,6 +238,13 @@ textarea.dark-area {
   color: #128770;
 }
 
+.coin-input {
+  padding-right: 10px;
+}
+.coin-input input {
+  min-width: 75px;
+}
+
 .alert .close {
   top:-7px;
 }


### PR DESCRIPTION
### Summary of Changes

- Even at the smallest end of large devices, all text can be read up to 3 digits and boxes do not overlap.
- Cleaned up unneeded columns and changed them to use col-offsets instead.

#### Small end of large devices

![](https://dl.dropboxusercontent.com/s/4q6avkjwhtl4sxx/Screenshot%202016-09-15%2012.43.51.png?dl=0)

#### Large devices normally

![](https://dl.dropboxusercontent.com/s/x6qerac5y4niz54/Screenshot%202016-09-15%2012.45.06.png?dl=0)

All other device sizes unchanged.

### Issues Fixed

Fixes #782 