### PR TITLE
Adds functionality to enforce data cleanup.

### DIFF
--- a/charactersheet/charactersheet/viewmodels/characters.js
+++ b/charactersheet/charactersheet/viewmodels/characters.js
@@ -77,16 +77,6 @@ function CharactersViewModel() {
     };
 
     self.removeCharacter = function(character) {
-        //Purge all entries for this char.
-        var tables = Object.keys(localStorage);
-        tables.forEach(function(table, iTable, _Table) {
-            PersistenceService._findAllObjs(table).forEach(function(item, iItem, _Item) {
-                if (item.data.characterId === character.key()) {
-                    PersistenceService._delete(table, item.id);
-                }
-            });
-        });
-
         //Remove the character.
         character.delete();
         self.characters.remove(character);

--- a/charactersheet/charactersheet/viewmodels/root.js
+++ b/charactersheet/charactersheet/viewmodels/root.js
@@ -266,6 +266,8 @@ function RootViewModel() {
             self.settingsViewModel().unload();
             self.wizardViewModel.unload();
         }
+
+        self._purgeStrayDBEntries();
     };
 
     //Private Methods
@@ -288,5 +290,25 @@ function RootViewModel() {
         } else {
             return 'hidden';
         }
+    };
+
+    /**
+     * Clear stray db entries. Entries that are either belonging to a
+     * non-existant or null character are removed.
+     */
+    self._purgeStrayDBEntries = function() {
+        var activeIDs = PersistenceService.findAll(Character).map(function(character, _i, _) {
+            return  character.key();
+        });
+        PersistenceService.listAll().forEach(function(table, idx, _) {
+            if (!window[table] || table === 'Character') { return; }
+            PersistenceService.findAllObjs(table).forEach(function(e1, i1,_1) {
+                var invalidID = e1.data['characterId'] === undefined || e1.data['characterId'] === null;
+                var expiredID = activeIDs.indexOf(e1.data['characterId']) === -1;
+                if (expiredID || invalidID) {
+                    PersistenceService.delete(window[table], e1.id);
+                }
+            });
+        });
     };
 }


### PR DESCRIPTION
### Summary of Changes

The following functionality was added to the unload process:
- Entries in any model table (excluding character) that contain a value for
  characterId that is null or undefined are removed.
- Entries for any model table (excluding character) that contain a value for
  characterId that is not present in the Character model table are removed.

This is a fairly crude, but effective method of cleaning out stray and null
entries. Ideas and suggestions for improvement welcome.

### Issues Fixed

Fixes #744 

### Changes Proposed (if any)

If anything this solidifies the use of the keyword `characterId` as the identifier of the character a model belongs to. Models are, of course, free to use any identifier, but they will not be automatically cleaned up.

