### PR TITLE
Genericises Data Loading Process.

### DIFF
--- a/charactersheet/charactersheet/init.js
+++ b/charactersheet/charactersheet/init.js
@@ -7,17 +7,11 @@ var init = function(viewModel) {
     ko.mapping.defaultOptions().ignore = Settings.mappingAlwaysIgnore;
 
     // Import static data
-    $.getJSON('https://adventurerscodex.com/data/SRD/spells.json',
-        function(data) {
-            DataRepository.spells = data;
-        }
-      );
-
-    $.getJSON('https://adventurerscodex.com/data/SRD/items.json',
-        function(data) {
-            DataRepository.items = data;
-        }
-      );
+    Settings.srdDataRepositoryLocations.forEach(function(location, idx, _) {
+        $.getJSON(location.url, function(data) {
+            DataRepository[location.key] = data;
+        });
+    });
 
     // Run migration
     PersistenceService.migrate(Fixtures.migration.scripts, Settings.version);

--- a/charactersheet/charactersheet/settings.js
+++ b/charactersheet/charactersheet/settings.js
@@ -36,5 +36,22 @@ var Settings = {
         // file types, such as "video" or "images" in the list. For more information,
         // see File types below. By default, all extensions are allowed.
         extensions: ['.json']
-    }
+    },
+
+    /**
+     * A set of Data Repository URLs and Keys. Each item in this list should
+     * contain both a URL and a Key.
+     *
+     * These values are fetched during initialization and the fetched values
+     * are set to DataRepository[key].
+     */
+    srdDataRepositoryLocations: [
+        {
+            key: 'items',
+            url: 'https://adventurerscodex.com/data/SRD/items.json'
+        }, {
+            key: 'spells',
+            url: 'https://adventurerscodex.com/data/SRD/spells.json'
+        }
+    ]
 };


### PR DESCRIPTION
### Summary of Changes

- Adds list of data repos to fetch to the `Settings.js`
- During init, fetch each of the datasets in the list, and set them to values in the `DataRepository`

**Note:** I decided to add this to `settings.js` not `fixtures.js` because it isn't the data itself, but instead a setting of where to find it.

### Issues Fixed

Fixes #835 

### Changes Proposed (if any)

None

### Screen Shot of Proposed Changes (if UI related)

None
