### PR TITLE
Set min to 0 for spell level in edit modal

### DIFF
--- a/charactersheet/charactersheet/templates/spells.tmpl.html
+++ b/charactersheet/charactersheet/templates/spells.tmpl.html
@@ -313,7 +313,7 @@
                     <input type="number"
                            class="form-control"
                            id="spellLevel"
-                           min="1"
+                           min="0"
                            max="9"
                            placeholder="1"
                            data-bind="value: spellLevel">


### PR DESCRIPTION
### Summary of Changes

Set min to 0 for spell level in edit modal

### Issues Fixed

Fixes #851 

### Screen Shot of Proposed Changes (if UI related)


<img width="531" alt="screen shot 2016-10-03 at 7 08 15 pm" src="https://cloud.githubusercontent.com/assets/5814150/19060420/eafcd2be-899c-11e6-9397-07b5dbaa5806.png">

