### PR TITLE
Adds new autoignore to mapping.

### DIFF
--- a/charactersheet/bin/knockout-mapping-autoignore.js
+++ b/charactersheet/bin/knockout-mapping-autoignore.js
@@ -1,0 +1,23 @@
+'use strict';
+
+/**
+ * A Knockout Mapping addition that will automatically add any field not
+ * included in the `include` list to the ignore list.
+ * This eliminates the need to explicitly enter both includes and ignores.
+ *
+ * Usage:
+ *
+ *   var mapping = {
+ *       include: ['name', 'address', 'zip code']
+ *   });
+ */
+ko.mapping.autoignore = function(obj, config) {
+    var includes = config.include || [];
+    var keys = Object.keys(obj);
+
+    config.ignore = config.ignore || [];
+    config.ignore = config.ignore.concat(keys.filter(function(key, idx, _) {
+        return includes.indexOf(key) === -1;
+    }));
+    return config;
+};

--- a/charactersheet/bin/knockout-mapping-autoignore.js
+++ b/charactersheet/bin/knockout-mapping-autoignore.js
@@ -7,9 +7,12 @@
  *
  * Usage:
  *
- *   var mapping = {
+ *  function MyModel() {
+ *   this.mapping = {
  *       include: ['name', 'address', 'zip code']
  *   });
+ *   var fullMapping = ko.mapping.autoignore(this, this.mapping);
+ *  }
  */
 ko.mapping.autoignore = function(obj, config) {
     var includes = config.include || [];

--- a/charactersheet/charactersheet/index.html
+++ b/charactersheet/charactersheet/index.html
@@ -252,6 +252,7 @@
 <script src="/bin/knockout-binding-contenteditable.js" type="text/javascript"></script>
 <script src="/bin/knockout-boostrap-collapse.js" type="text/javascript"></script>
 <script src="/bin/knockout-bootstrap-modal.js" type="text/javascript"></script>
+<script src="/bin/knockout-mapping-autoignore.js" type="text/javascript"></script>
 <!-- ViewModels -->
 <script src="viewmodels/character/ability_scores.js" type="text/javascript"></script>
 <script src="viewmodels/character/actions_toolbar.js" type="text/javascript"></script>

--- a/charactersheet/charactersheet/models/character/ability_scores.js
+++ b/charactersheet/charactersheet/models/character/ability_scores.js
@@ -4,9 +4,7 @@ function AbilityScores() {
     var self = this;
     self.ps = PersistenceService.register(AbilityScores, self);
     self.mapping = {
-        ignore: ['ps', 'mapping', 'strModifier', 'dexModifier', 'conModifier',
-            'intModifier', 'wisModifier', 'chaModifier', 'modifierFor', 'clear',
-            'exportValues', 'importValues', 'save']
+        include: ['characterId', 'str', 'dex', 'con', 'int', 'wis', 'cha']
     };
 
     self.characterId = ko.observable(null);
@@ -70,15 +68,18 @@ function AbilityScores() {
 
     self.clear = function() {
         var values = new AbilityScores().exportValues();
-        ko.mapping.fromJS(values, self.mapping, self);
+        var mapping = ko.mapping.autoignore(self, self.mapping);
+        ko.mapping.fromJS(values, mapping, self);
     };
 
     self.importValues = function(values) {
-        ko.mapping.fromJS(values, self.mapping, self);
+        var mapping = ko.mapping.autoignore(self, self.mapping);
+        ko.mapping.fromJS(values, mapping, self);
     };
 
     self.exportValues = function() {
-        return ko.mapping.toJS(self, self.mapping);
+        var mapping = ko.mapping.autoignore(self, self.mapping);
+        return ko.mapping.toJS(self, mapping);
     };
 
     self.save = function() {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -21,6 +21,7 @@ module.exports = function(config) {
 			{pattern: 'charactersheet/bin/koExternalTemplateEngine_all.min.js', watched: false},
 			{pattern: 'charactersheet/bin/markdown.min.js', watched: false},
 			{pattern: 'charactersheet/bin/knockout.mapping.js', watched: false},
+			{pattern: 'charactersheet/bin/knockout-mapping-autoignore.js', watched: false},
 			//Stuff to test.
 			'charactersheet/charactersheet/**/*root.js',
 			'charactersheet/charactersheet/**/*.js',


### PR DESCRIPTION
### Summary of Changes

- Currently, fields that must be ignored, or included in model serialization must be explicitly specified in the KO Mapping fields. This leads to redundant specification since it can be implied that if a field should not be included, then it should be excluded. This adds a new extension to `ko.mapping` that automatically ignores any fields that aren't specified in the `mapping.include` list.
  - Additional fields may be ignored explicitly.
- An example is implemented in the Ability Scores.

### Issues Fixed

None logged.

### Changes Proposed (if any)

None.

### Screen Shot of Proposed Changes (if UI related)

None.