### PR TITLE
Only show magical modifier badge on weapons widget if there is a modifier

### DIFF
--- a/charactersheet/charactersheet/models/common/weapon.js
+++ b/charactersheet/charactersheet/models/common/weapon.js
@@ -144,7 +144,15 @@ function Weapon() {
             return magicalModifier >= 0 ? ('+ ' + magicalModifier) : '- ' +
             Math.abs(magicalModifier);
         } else {
-            return '+ 0';
+            return '';
+        }
+    });
+
+    self.applyMagicalModifierLabel = ko.pureComputed(function() {
+        if (self.magicalModifierLabel() !== '' ){
+            return true;
+        } else {
+            return false;
         }
     });
 

--- a/charactersheet/charactersheet/templates/character/weapons.tmpl.html
+++ b/charactersheet/charactersheet/templates/character/weapons.tmpl.html
@@ -156,7 +156,7 @@
                 <label for="weaponHit"
                        class="col-sm-2 control-label">Magical Modifier</label>
                 <div class="col-sm-10">
-                  <input type="number" min="-10" class="form-control"
+                  <input type="number" class="form-control"
                          id="weaponHit"
                          placeholder="Place hit bonus here"
                          data-bind='textInput: blankWeapon().weaponHit'>
@@ -346,7 +346,7 @@
                 <label for="weaponHit"
                        class="col-sm-2 control-label">Magical Modifier</label>
                 <div class="col-sm-10">
-                  <input type="number" min="-10" class="form-control"
+                  <input type="number" class="form-control"
                          id="weaponHit"
                          placeholder="Place hit bonus here"
                          data-bind='textInput: weaponHit'>

--- a/charactersheet/charactersheet/templates/character/weapons.tmpl.html
+++ b/charactersheet/charactersheet/templates/character/weapons.tmpl.html
@@ -52,7 +52,7 @@
               data-target="#viewWeapon">
               <span data-bind="text: weaponName">
               </span>&nbsp;
-              <span data-bind="text: magicalModifierLabel" class="badge">
+              <span data-bind="text: magicalModifierLabel, css: { badge: applyMagicalModifierLabel }">
               </span>
           </td>
           <td data-bind="text: hitBonusLabel, click: $parent.editWeapon"

--- a/charactersheet/charactersheet/templates/character/weapons.tmpl.html
+++ b/charactersheet/charactersheet/templates/character/weapons.tmpl.html
@@ -156,7 +156,7 @@
                 <label for="weaponHit"
                        class="col-sm-2 control-label">Magical Modifier</label>
                 <div class="col-sm-10">
-                  <input type="number" min="0" class="form-control"
+                  <input type="number" min="-10" class="form-control"
                          id="weaponHit"
                          placeholder="Place hit bonus here"
                          data-bind='textInput: blankWeapon().weaponHit'>
@@ -346,7 +346,7 @@
                 <label for="weaponHit"
                        class="col-sm-2 control-label">Magical Modifier</label>
                 <div class="col-sm-10">
-                  <input type="number" min="0" class="form-control"
+                  <input type="number" min="-10" class="form-control"
                          id="weaponHit"
                          placeholder="Place hit bonus here"
                          data-bind='textInput: weaponHit'>

--- a/test/models/test_weapon.js
+++ b/test/models/test_weapon.js
@@ -207,7 +207,22 @@ describe('Weapon Model', function() {
             weap.weaponHit();
 
             var totalBonus = weap.magicalModifierLabel();
-            totalBonus.should.equal('+ 0');
+            totalBonus.should.equal('');
+        });
+    });
+
+    describe('Apply Magical Modifier Label', function() {
+        it('should return true if there is a magicalModifierLabel', function() {
+            var weap = new Weapon();
+            weap.weaponHit(2);
+
+            weap.applyMagicalModifierLabel().should.equal(true);
+        });
+        it('should return false if there is on magicalModifierLabel', function() {
+            var weap = new Weapon();
+            weap.weaponHit(0);
+
+            weap.applyMagicalModifierLabel().should.equal(false);
         });
     });
 });


### PR DESCRIPTION
### Summary of Changes

Only show magical modifier badge on weapons widget if there is a modifier

### Issues Fixed

Fixes #941

### Screen Shot of Proposed Changes (if UI related)

<img width="869" alt="screen shot 2016-11-02 at 5 38 17 am" src="https://cloud.githubusercontent.com/assets/5814150/19929104/ffdccc32-a0be-11e6-8623-4d85fae918fe.png">

