### PR TITLE
Profile image redesign

### DIFF
--- a/charactersheet/charactersheet/index.html
+++ b/charactersheet/charactersheet/index.html
@@ -58,7 +58,7 @@
           <div class="col-padded col-xs-2" data-bind="template: {
             name: 'player_image.tmpl',
             templateUrl: 'templates/character',
-            data: profileTabViewModel().playerImageViewModel()
+            data: playerImageViewModel
           }"></div>
           <!-- /ko -->
           <!-- /ko -->
@@ -89,9 +89,6 @@
                   data-target="#exportModal"
                   data-bind="click: charactersViewModel.selectCharacter"
                   href="#">Export</a></i>
-                &nbsp;
-                <i class="small underline"><a class="" data-toggle="modal"
-                  data-target="#settingsModal" href="#">Settings</a></i>
               </div>
             </div>
           </div>
@@ -191,15 +188,6 @@
       </div>
     </div>
   </div>
-</div>
-
-<!-- Settings Modal -->
-<div class="modal fade" id="settingsModal" tabindex="-1" role="dialog"
-  aria-labelledby="settingsLabel"
-  data-bind="template: {
-      name: 'settings.tmpl',
-      templateUrl: 'templates/common',
-      data: settingsViewModel }">
 </div>
 
 <!-- New Modal -->

--- a/charactersheet/charactersheet/index.html
+++ b/charactersheet/charactersheet/index.html
@@ -306,6 +306,7 @@
 <script src="models/common/magic_item.js" type="text/javascript"></script>
 <script src="models/common/note.js" type="text/javascript"></script>
 <script src="models/common/player_info.js" type="text/javascript"></script>
+<script src="models/common/player_image.js" type="text/javascript"></script>
 <script src="models/common/player_types.js" type="text/javascript"></script>
 <script src="models/common/spell.js" type="text/javascript"></script>
 <script src="models/common/treasure.js" type="text/javascript"></script>

--- a/charactersheet/charactersheet/models/common/image.js
+++ b/charactersheet/charactersheet/models/common/image.js
@@ -5,19 +5,7 @@ function ImageModel() {
     self.ps = PersistenceService.register(ImageModel, self);
 
     self.characterId = ko.observable(null);
-
-    /**
-     * The image data.
-     */
     self.imageUrl = ko.observable();
-
-    /**
-     * The raw image data. This is not saved and is compressed. For the
-     * right sized image, use imageUrl.
-     */
-    self.dataUrl = ko.observable();
-    self.height = ko.observable(80);
-    self.width = ko.observable(80);
 
     self.save = function() {
         self.ps.save();
@@ -39,14 +27,6 @@ function ImageModel() {
         };
     };
 
-    self.resize = function() {
-        var compData = ImageModel.resizeImageData(
-            self.dataUrl(), self.height(), self.width());
-        self.imageUrl(compData);
-        self.save();
-    };
-    self.dataUrl.subscribe(self.resize);
-
     /**
      * Returns whether or not the image is empty.
      */
@@ -63,44 +43,4 @@ ImageModel.findBy = function(characterId) {
     return PersistenceService.findAll(ImageModel).filter(function(e, i, _) {
         return e.characterId() === characterId;
     });
-};
-
-/**
- * Given a dataURL for an uncompressed image, return the compressed
- * version of the URL.
- * Via: https://github.com/josefrichter/resize/blob/master/public/preprocess.js
- */
-ImageModel.resizeImageData = function(dataUrl, max_height, max_width) {
-    var img = new Image();
-    img.src = dataUrl;
-    var canvas = document.createElement('canvas');
-
-    var width = img.width;
-    var height = img.height;
-
-    // calculate the width and height, constraining the proportions
-    if (width > height) {
-        if (width > max_width) {
-            //height *= max_width / width;
-            height = Math.round(height *= max_width / width);
-            width = max_width;
-        }
-    } else {
-        if (height > max_height) {
-            //width *= max_height / height;
-            width = Math.round(width *= max_height / height);
-            height = max_height;
-        }
-    }
-
-    // resize the canvas and draw the image data into it
-    canvas.width = width;
-    canvas.height = height;
-    var ctx = canvas.getContext('2d');
-    ctx.drawImage(img, 0, 0, width, height);
-
-    //preview.appendChild(canvas); // do the actual resized preview
-
-    var data = canvas.toDataURL('image/jpeg'); // get the data from canvas as 70% JPG (can be also PNG, etc.)
-    return data.length < 10 ? dataUrl : data;
 };

--- a/charactersheet/charactersheet/models/common/player_image.js
+++ b/charactersheet/charactersheet/models/common/player_image.js
@@ -1,0 +1,33 @@
+'use strict';
+
+function PlayerImage() {
+    var self = this;
+    self.ps = PersistenceService.register(PlayerImage, self);
+
+    self.mapping = {
+        include: ['characterId', 'imageSource']
+    };
+
+    self.characterId = ko.observable(null);
+    self.imageSource = ko.observable();
+
+    self.clear = function() {
+        var values = new AbilityScores().exportValues();
+        var mapping = ko.mapping.autoignore(self, self.mapping);
+        ko.mapping.fromJS(values, mapping, self);
+    };
+
+    self.importValues = function(values) {
+        var mapping = ko.mapping.autoignore(self, self.mapping);
+        ko.mapping.fromJS(values, mapping, self);
+    };
+
+    self.exportValues = function() {
+        var mapping = ko.mapping.autoignore(self, self.mapping);
+        return ko.mapping.toJS(self, mapping);
+    };
+
+    self.save = function() {
+        self.ps.save();
+    };
+}

--- a/charactersheet/charactersheet/templates/character/player_image.tmpl.html
+++ b/charactersheet/charactersheet/templates/character/player_image.tmpl.html
@@ -1,23 +1,76 @@
-<div class="circular-profile no-padding"
-  data-bind="fileDrag: dropzone, attr: {
-    height: playerImageHeight,
-    width: playerImageWidth,
-  }, css: imageBorderClass">
+<div class="circular-profile no-padding" style="cursor: pointer;"
+  data-bind="click: toggleModal,
+    attr: {
+      height: height,
+      width: width,
+    },
+    css: imageBorderClass">
   <div class="image-upload-preview text-center">
-    <!-- ko if: hasImage -->
+    <!-- ko if: playerImageSrc -->
     <img class="img-circle"
       data-bind="attr: {
         src: playerImageSrc,
-        height: playerImageHeight,
-      }, visible: playerImageSrc">
+        height: height,
+        width: width,
+      }">
     <!-- /ko -->
-    <!-- ko ifnot: hasImage -->
+    <!-- ko ifnot: playerImageSrc -->
     <div class="text-muted player-image-style">
-      Drop a profile pic here</div>
+      <small>Click to add a picture</small>
+    </div>
     <!-- /ko -->
   </div>
-  <div class="image-upload-input">
-    <input type="file" class="hide-block"
-      data-bind="fileInput: dropzone">
-  </div>
+</div>
+
+<!-- Modal -->
+<div class="modal fade" tabindex="-1" role="dialog"
+   aria-labelledby="viewSkillLabel"
+   data-bind="modal: {
+      open: openModal,
+      onopen: modalFinishedOpening,
+      onclose: modalFinishedClosing
+    }">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal"
+                aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <h4 class="modal-title" id="addSkillLabel">
+          Edit your Profile Image
+        </h4>
+      </div>
+      <div class="modal-body">
+        <form class="form-horizontal" onsubmit="return false">
+          <div class="h4">Enter one of the following.</div><br />
+          <div class="form-group">
+            <!-- Image URL -->
+            <label for="spellName"
+                   class="col-sm-4 control-label">Profile Image Link</label>
+            <div class="col-sm-8">
+              <input type="text"
+                     class="form-control"
+                     data-bind="value: imageUrl, hasFocus: firstFieldHasFocus">
+            </div>
+          </div>
+          <div class="form-group">
+            <!-- Gravatar -->
+            <label for="spellName"
+                   class="col-sm-4 control-label">Gravatar Email</label>
+            <div class="col-sm-8">
+              <input type="text"
+                     class="form-control"
+                     data-bind="value: email">
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button"
+                    class="btn btn-primary"
+                    data-dismiss="modal">Done</button>
+          </div> <!-- Modal Footer -->
+        </form>
+      </div> <!-- Modal Content -->
+    </div> <!-- Modal Dialog -->
+  </div> <!-- Modal Fade -->
 </div>

--- a/charactersheet/charactersheet/templates/character/player_image.tmpl.html
+++ b/charactersheet/charactersheet/templates/character/player_image.tmpl.html
@@ -38,22 +38,47 @@
           <span aria-hidden="true">&times;</span>
         </button>
         <h4 class="modal-title" id="addSkillLabel">
-          Edit your Profile Image
+          Choose one of the following
         </h4>
       </div>
       <div class="modal-body">
         <form class="form-horizontal" onsubmit="return false">
-          <div class="h4">Enter one of the following.</div><br />
+          <div class="form-group">
+            <div class="col-sm-12">
+              <div class="btn-group btn-group-justified" role="group">
+                <label class="btn btn-default"
+                data-bind="css: { active: imageSource() == 'link'}">
+                  <input type="radio" class="hide-block"
+                  name="imageSourceLink" value="link" data-bind="checked: imageSource"/>
+                  Image Link
+                </label>
+                <label class="btn btn-default"
+                data-bind="css: { active: imageSource() == 'email'}">
+                  <input type="radio" class="hide-block"
+                  name="imageSourceEmail" value="email" data-bind="checked: imageSource"/>
+                  Gravatar Email
+                </label>
+              </div>
+            </div>
+          </div>
+          <!-- ko if: imageSource() == 'link' -->
           <div class="form-group">
             <!-- Image URL -->
             <label for="spellName"
-                   class="col-sm-4 control-label">Profile Image Link</label>
+                   class="col-sm-4 control-label">Image Link</label>
             <div class="col-sm-8">
               <input type="text"
                      class="form-control"
                      data-bind="value: imageUrl, hasFocus: firstFieldHasFocus">
             </div>
           </div>
+          <div class="row">
+            <div class="col-sm-offset-1 col-xs-10">
+            <p class="text-muted text-center"><small>Paste in a link to your favorite profile picture. Make sure it's the full image link though.</small></p>
+            </div>
+          </div>
+          <!-- /ko -->
+          <!-- ko if: imageSource() == 'email' -->
           <div class="form-group">
             <!-- Gravatar -->
             <label for="spellName"
@@ -64,6 +89,12 @@
                      data-bind="value: email">
             </div>
           </div>
+          <div class="row">
+            <div class="col-sm-offset-1 col-xs-10">
+            <p class="text-muted text-center"><small><a href="http://en.gravatar.com" target="_blank">Gravatar is a free service</a> that allows you to set a profile picture based on your email, and it works in lots of places.</small></p>
+            </div>
+          </div>
+          <!-- /ko -->
           <div class="modal-footer">
             <button type="button"
                     class="btn btn-primary"

--- a/charactersheet/charactersheet/templates/common/settings.tmpl.html
+++ b/charactersheet/charactersheet/templates/common/settings.tmpl.html
@@ -8,12 +8,6 @@
       <h4 class="modal-title" id="settingsLabel"
         data-dismiss="modal">Settings</h4>
     </div>
-    <div class="modal-body">
-      <div data-bind="template: {
-        name: 'player_info.tmpl',
-        templateUrl: 'templates/common',
-        data: playerInfoViewModel
-      }"></div>
     </div>
     <div class="modal-footer">
       <button type="button" class="btn btn-primary"

--- a/charactersheet/charactersheet/viewmodels/character/character_root.js
+++ b/charactersheet/charactersheet/viewmodels/character/character_root.js
@@ -21,6 +21,8 @@ function CharacterRootViewModel() {
     self.inventoryTabViewModel     = ko.observable(new InventoryTabViewModel());
     self.notesTabViewModel         = ko.observable(new NotesTabViewModel());
 
+    self.playerImageViewModel    = ko.observable(new PlayerImageViewModel());
+
     //Tooltips
     self.profileTooltip = ko.observable('Profile');
     self.statsTooltip = ko.observable('Stats');

--- a/charactersheet/charactersheet/viewmodels/character/player_image.js
+++ b/charactersheet/charactersheet/viewmodels/character/player_image.js
@@ -102,7 +102,7 @@ function PlayerImageViewModel() {
         }
 
         var url = self._getEmailUrl();
-        if (self.imageSource() == 'email') {
+        if (self.imageSource() == 'email' && self.email()) {
             return url;
         }
 

--- a/charactersheet/charactersheet/viewmodels/character/player_image.js
+++ b/charactersheet/charactersheet/viewmodels/character/player_image.js
@@ -26,6 +26,7 @@ function PlayerImageViewModel() {
             self.image(image[0]);
         } else {
             self.image(new ImageModel());
+            self.image().characterId(CharacterManager.activeCharacter().key());
         }
 
         //Subscriptions

--- a/charactersheet/charactersheet/viewmodels/character/player_image.js
+++ b/charactersheet/charactersheet/viewmodels/character/player_image.js
@@ -5,6 +5,7 @@ function PlayerImageViewModel() {
 
     self.openModal = ko.observable(false);
 
+    self.imageSource = ko.observable();
     self.imageUrl = ko.observable('');
     self.email = ko.observable('');
     self.height = ko.observable(80);
@@ -36,9 +37,19 @@ function PlayerImageViewModel() {
             info.save();
         }
 
+        var playerImageSource = PersistenceService.findFirstBy(PlayerImage, 'characterId', key);
+        if (playerImageSource) {
+            self.imageSource(playerImageSource.imageSource());
+        }else {
+            var playerImageSource = new PlayerImage();
+            playerImageSource.characterId(key);
+            playerImageSource.save();
+        }
+
         //Subscriptions
         self.email.subscribe(self.dataHasChanged);
         self.imageUrl.subscribe(self.dataHasChanged);
+        self.imageSource.subscribe(self.dataHasChanged);
         Notifications.playerInfo.changed.add(self.dataHasChanged);
     };
 
@@ -71,6 +82,12 @@ function PlayerImageViewModel() {
             image.imageUrl(self.imageUrl());
             image.save();
         }
+
+        var playerImageSource = PersistenceService.findFirstBy(PlayerImage, 'characterId', key);
+        if (playerImageSource) {
+            playerImageSource.imageSource(self.imageSource());
+            playerImageSource.save();
+        }
     };
 
     self.imageBorderClass = ko.pureComputed(function() {
@@ -80,12 +97,12 @@ function PlayerImageViewModel() {
     //Player Image Handlers
 
     self.playerImageSrc = ko.pureComputed(function() {
-        if (self.imageUrl()) {
+        if (self.imageSource() == 'link') {
             return self.imageUrl();
         }
 
         var url = self._getEmailUrl();
-        if (self.email() && url) {
+        if (self.imageSource() == 'email') {
             return url;
         }
 

--- a/charactersheet/charactersheet/viewmodels/character/profile_tab.js
+++ b/charactersheet/charactersheet/viewmodels/character/profile_tab.js
@@ -9,8 +9,6 @@ function ProfileTabViewModel() {
     self.profileViewModel        = ko.observable(new ProfileViewModel());
     self.appearanceViewModel     = ko.observable(new AppearanceViewModel());
     self.featuresTraitsViewModel = ko.observable(new FeaturesTraitsViewModel());
-    self.playerImageViewModel    = ko.observable(new PlayerImageViewModel());
-    self.playerInfoViewModel     = ko.observable(new PlayerInfoViewModel());
 
     self.init = function() {
         ViewModelUtilities.initSubViewModels(self);

--- a/charactersheet/site.css
+++ b/charactersheet/site.css
@@ -206,6 +206,11 @@ div.hr {
   border:none;
 }
 
+.dashed-border {
+  border-style: dashed;
+  border-color: lightgray;
+}
+
 .underline {
   text-decoration: underline;
 }
@@ -359,7 +364,9 @@ textarea.dark-area {
 }
 
 .player-image-style {
-  margin-top:7px;
+  margin-top:4px;
+  margin-left: 6px;
+  margin-right: 6px;
 }
 
 .spell-slots-level {

--- a/test/models/test_image.js
+++ b/test/models/test_image.js
@@ -46,14 +46,6 @@ describe('Image Model', function() {
             });
         });
     });
-    describe('Resize Image Data', function() {
-        it('should return a data url of the compressed image, or if the' +
-             'conversion fails, it should return the original image.', function() {
-            //Should Fail.
-            var comp = ImageModel.resizeImageData(ImageFixture.dataUrl, 100, 100);
-            comp.should.equal(ImageFixture.dataUrl);
-        });
-    });
     describe('Find By', function() {
         it('Should return a list of image models matching the given id.', function() {
             //Empty


### PR DESCRIPTION
### Summary of Changes

Redesigns Player Image UI and Code. 
- Players can no longer save images by dragging them into the circle (this was
  unfriendly to mobile to start anyway).
- Instead, players click/tap on the circle and are presented with a modal
  prompting them to enter either (or both I guess) a remote image URL or their
gravatar email.
    - This approach greatly simplifies the amount of code needed to store
      actual images and improves the user's experience of using the app. Images
are huge in comparison with the campacity of LocalStorage (and later, sending
them over the wire might be too complex anyway).
- This also greatly simplifies the code needed for managing profile images.
- Since the original spot for the Player's Gravatar Email was in the Settings, and it was the only field. I have removed the settings Modal and link from the UI. 
  - This does not remove the templates however.

### Issues Fixed

Fixes #964 

### Changes Proposed (if any)

None 

### Screen Shot of Proposed Changes (if UI related)

![screenshot 2016-11-10 16 00 58](https://cloud.githubusercontent.com/assets/3310280/20199382/e75a03ae-a75e-11e6-9631-646b4551a782.png)
![screenshot 2016-11-10 16 01 00](https://cloud.githubusercontent.com/assets/3310280/20199383/e76e7b36-a75e-11e6-8446-e16b4b5b1c91.png)