### PR TITLE
Truncate characters in table column

### DIFF
--- a/charactersheet/charactersheet/models/common/item.js
+++ b/charactersheet/charactersheet/models/common/item.js
@@ -6,6 +6,9 @@
  */
 function Item() {
     var self = this;
+
+    self.DESCRIPTION_MAX_LENGTH = 200;
+
     self.ps = PersistenceService.register(Item, self);
     self.mapping = {
         ignore: ['clear', 'ps', 'importValues', 'exportValues', 'save',
@@ -29,6 +32,12 @@ function Item() {
             return parseInt(self.itemQty()) * parseFloat(self.itemWeight());
         }
         return 0;
+    });
+
+    self.shortDescription = ko.pureComputed(function() {
+        if (self.itemDesc()) {
+            return self.itemDesc().substring(0, self.DESCRIPTION_MAX_LENGTH);
+        }
     });
 
     self.clear = function() {

--- a/charactersheet/charactersheet/models/common/item.js
+++ b/charactersheet/charactersheet/models/common/item.js
@@ -36,7 +36,7 @@ function Item() {
 
     self.shortDescription = ko.pureComputed(function() {
         if (self.itemDesc()) {
-            return self.itemDesc().substring(0, self.DESCRIPTION_MAX_LENGTH);
+            return self.itemDesc().substring(0, self.DESCRIPTION_MAX_LENGTH) + '...';
         }
     });
 

--- a/charactersheet/charactersheet/models/common/magic_item.js
+++ b/charactersheet/charactersheet/models/common/magic_item.js
@@ -2,8 +2,10 @@
 
 function MagicItem() {
     var self = this;
-    self.ps = PersistenceService.register(MagicItem, self);
 
+    self.DESCRIPTION_MAX_LENGTH = 145;
+
+    self.ps = PersistenceService.register(MagicItem, self);
     self.mapping = {
         ignore: ['clear', 'ps', 'importValues', 'exportValues', 'save',
                  'delete', 'chargesDisplay', 'magicItemTypeOptions',
@@ -38,6 +40,12 @@ function MagicItem() {
             return self.magicItemDescription().replace(/\n/g, '<br />');
         } else {
             return '<div class="h3"><small>Add a description via the edit tab.</small></div>';
+        }
+    });
+
+    self.shortDescription = ko.pureComputed(function() {
+        if (self.magicItemDescription()) {
+            return self.magicItemDescription().substring(0, self.DESCRIPTION_MAX_LENGTH) + '...';
         }
     });
 

--- a/charactersheet/charactersheet/templates/character/items.tmpl.html
+++ b/charactersheet/charactersheet/templates/character/items.tmpl.html
@@ -30,7 +30,7 @@
                   href="#"></td>
           <td data-bind="text: itemWeight, click: $parent.editItemButton"
                   href="#"></td>
-          <td data-bind="text: itemDesc, click: $parent.editItemButton"
+          <td data-bind="text: shortDescription, click: $parent.editItemButton"
                   href="#"></td>
           <td>
             <a data-bind='click: $parent.removeItemButton' href="#">

--- a/charactersheet/charactersheet/templates/character/items.tmpl.html
+++ b/charactersheet/charactersheet/templates/character/items.tmpl.html
@@ -12,7 +12,7 @@
           <th data-bind="click: function(){sortBy('itemWeight');}">
             Weight
             <span data-bind="css: sortArrow('itemWeight')"></span></th>
-          <th>Description</th>
+          <th class="hidden-sm hidden-xs">Description</th>
           <th>
            <a data-toggle="modal"
             data-target="#addItem" href="#">
@@ -30,8 +30,8 @@
                   href="#"></td>
           <td data-bind="text: itemWeight, click: $parent.editItemButton"
                   href="#"></td>
-          <td data-bind="text: shortDescription, click: $parent.editItemButton"
-                  href="#"></td>
+          <td class="hidden-sm hidden-xs" data-bind="text: shortDescription,
+            click: $parent.editItemButton" href="#"></td>
           <td>
             <a data-bind='click: $parent.removeItemButton' href="#">
               <i class="fa fa-trash-o fa-color-hover"></i>

--- a/charactersheet/charactersheet/templates/character/magic_items.tmpl.html
+++ b/charactersheet/charactersheet/templates/character/magic_items.tmpl.html
@@ -20,7 +20,7 @@
             Weight
             <span data-bind="css: sortArrow('magicItemWeight')"></span>
           </th>
-          <th width="48%">
+          <th width="48%" class="hidden-sm hidden-xs">
             Description
           </th>
           <th width="5%">
@@ -52,7 +52,7 @@
               href="#"
               data-target="#viewMagicItem">
           </td>
-          <td data-bind="text: magicItemDescription, click: $parent.editItem"
+          <td data-bind="text: shortDescription, click: $parent.editItem"
             href="#" class="hidden-sm hidden-xs"
             data-target="#viewMagicItem">
          </td>

--- a/charactersheet/charactersheet/viewmodels/character/items.js
+++ b/charactersheet/charactersheet/viewmodels/character/items.js
@@ -6,16 +6,10 @@ function ItemsViewModel() {
     self.sorts = {
         'itemName asc': { field: 'itemName', direction: 'asc'},
         'itemName desc': { field: 'itemName', direction: 'desc'},
-        'itemIsEquippable asc': { field: 'itemIsEquippable', direction: 'asc'},
-        'itemIsEquippable desc': { field: 'itemIsEquippable', direction: 'desc'},
         'itemQty asc': { field: 'itemQty', direction: 'asc', numeric: true},
         'itemQty desc': { field: 'itemQty', direction: 'desc', numeric: true},
         'itemWeight asc': { field: 'itemWeight', direction: 'asc', numeric: true},
         'itemWeight desc': { field: 'itemWeight', direction: 'desc', numeric: true},
-        'itemCost asc': { field: 'itemCost', direction: 'asc', numeric: true},
-        'itemCost desc': { field: 'itemCost', direction: 'desc', numeric: true},
-        'itemBodyLocation asc': { field: 'itemBodyLocation', direction: 'asc'},
-        'itemBodyLocation desc': { field: 'itemBodyLocation', direction: 'desc'}
     };
 
     self.items = ko.observableArray([]);


### PR DESCRIPTION
### Summary of Changes

Cuts down on long descriptions. Below are how the short descriptions appear on devices. The column is hidden on sm and xs.
@adventurerscodex/core-developers Feedback on character limit appreciated.

### Issues Fixed

Fixes #902 

### Screen Shot of Proposed Changes (if UI related)

**Large:**
![image](https://cloud.githubusercontent.com/assets/7286387/20207513/9e234216-a79c-11e6-9f44-80d3e2dbe546.png)

**Medium:**

![image](https://cloud.githubusercontent.com/assets/7286387/20207533/ba6b44fa-a79c-11e6-8def-4991c4e60e2f.png)

**Small:**
![image](https://cloud.githubusercontent.com/assets/7286387/20207539/caaedafc-a79c-11e6-921a-a3a6c655e939.png)

**Extra-small:**
![image](https://cloud.githubusercontent.com/assets/7286387/20207551/df84f66e-a79c-11e6-935d-6b1c4d24012c.png)


