### PR TITLE
Add markdown link to notes widget

### DIFF
--- a/charactersheet/charactersheet/templates/character/notes.tmpl.html
+++ b/charactersheet/charactersheet/templates/character/notes.tmpl.html
@@ -35,6 +35,14 @@
             </div>
           </div>
         </div>
+        <div class="panel-footer">
+        <div class="h4">
+          <small>Text in this panel can be styled using Markdown. Click
+            <a target="_blank" href="https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet">here</a>
+            to see a guide.
+          </small>
+        </div>
+        </div>
       </div>
       <!-- /ko -->
     </div>


### PR DESCRIPTION
### Summary of Changes

Add markdown link to notes widget

### Issues Fixed

Fixes #992 

### Screen Shot of Proposed Changes (if UI related)

<img width="864" alt="screen shot 2016-11-15 at 6 13 38 am" src="https://cloud.githubusercontent.com/assets/5814150/20308927/cfb49602-aafa-11e6-874d-238967e5cc88.png">


