### PR TITLE
Updates init logic in markdown-component.

### DIFF
--- a/charactersheet/charactersheet/components/markdown-edit-preview.js
+++ b/charactersheet/charactersheet/components/markdown-edit-preview.js
@@ -20,7 +20,7 @@ function MarkdownEditPreviewComponentViewModel(params) {
     self.placeholder = params.placeholder || ko.observable();
     self.previewHeight = params.previewHeight || ko.observable(0);
 
-    self.previewTabStatus = ko.observable('active');
+    self.previewTabStatus = ko.observable('');
     self.editTabStatus = ko.observable('');
 
     /* UI Methods */
@@ -35,8 +35,11 @@ function MarkdownEditPreviewComponentViewModel(params) {
         self.previewTabStatus('');
     };
 
-    // Select the default tab.
-    if (ko.unwrap(params.defaultActiveTab) === 'edit') {
+    // Select the default tab,
+    // or the preview tab if there's existing content.
+    if (ko.unwrap(self.text) || ko.unwrap(params.defaultActiveTab) === 'preview') {
+        self.selectPreviewTab();
+    } else {
         self.selectEditTab();
     }
 }

--- a/charactersheet/charactersheet/templates/character/notes.tmpl.html
+++ b/charactersheet/charactersheet/templates/character/notes.tmpl.html
@@ -31,7 +31,7 @@
           <div class="row">
             <div class="col-xs-12">
               <markdown-edit-preview params="text: text, rows: 15, previewHeight: 200,
-                placeholder: 'Captain\'s Log...', defaultActiveTab: 'edit'"></markdown-edit-preview>
+                placeholder: 'Captain\'s Log...'"></markdown-edit-preview>
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Summary of Changes

- Component now sets the default tab to preview if there is existing content.
  Use the default to override this behavior. A lack of content will cause edit
to be selected.

### Issues Fixed

Fixes #996 

### Changes Proposed (if any)

None

### Screen Shot of Proposed Changes (if UI related)

None
