### PR TITLE
Sets image link as the default for players, and fixes bug.

### DIFF
--- a/charactersheet/charactersheet/viewmodels/character/player_image.js
+++ b/charactersheet/charactersheet/viewmodels/character/player_image.js
@@ -5,7 +5,7 @@ function PlayerImageViewModel() {
 
     self.openModal = ko.observable(false);
 
-    self.imageSource = ko.observable();
+    self.imageSource = ko.observable('link');
     self.imageUrl = ko.observable('');
     self.email = ko.observable('');
     self.height = ko.observable(80);
@@ -40,7 +40,7 @@ function PlayerImageViewModel() {
         var playerImageSource = PersistenceService.findFirstBy(PlayerImage, 'characterId', key);
         if (playerImageSource) {
             self.imageSource(playerImageSource.imageSource());
-        }else {
+        } else {
             var playerImageSource = new PlayerImage();
             playerImageSource.characterId(key);
             playerImageSource.save();
@@ -55,7 +55,7 @@ function PlayerImageViewModel() {
 
     self.unload = function() {
         self.save();
-        Notifications.playerInfo.changed.remove(self.checkImage);
+        Notifications.playerInfo.changed.remove(self.dataHasChanged);
     };
 
     self.dataHasChanged = function() {


### PR DESCRIPTION
### Summary of Changes

- Old players will see their image persist as now the image link option is
  selected by default.
- Fixes an issue where player images were not unloaded properly.

### Issues Fixed

Fixes #993 
Fixes #995 

### Changes Proposed (if any)

None

### Screen Shot of Proposed Changes (if UI related)

None
