### PR TITLE
Fixes issue with reloading encounters.

### DIFF
--- a/charactersheet/charactersheet/components/nested-list.js
+++ b/charactersheet/charactersheet/components/nested-list.js
@@ -20,11 +20,11 @@
  *
  * Note: This binding recursively uses itself to render it's children.
  */
-function EncounterListComponentViewModel(params) {
+function NestedListComponentViewModel(params) {
     var self = this;
 
-    self.encounters = params.encounters || ko.observableArray();
-    self.selectedEncounter = params.selectedEncounter || ko.observable();
+    self.cells = params.cells || ko.observableArray();
+    self.selectedCell = params.selectedCell || ko.observable();
     self.ondelete = params.ondelete;
     self.onadd = params.onadd;
 
@@ -34,51 +34,53 @@ function EncounterListComponentViewModel(params) {
         self.levels = 4;
     }
 
-    self.selectEncounter = function(encounter) {
-        self.selectedEncounter(encounter);
+    self.selectCell = function(cell) {
+        self.selectedCell(cell);
     };
 
     /**
      * Fires the `ondelete` callback to the responder.
      */
-    self.deleteEncounter = function(encounter) {
+    self.deleteCell = function(cell) {
         if (self.ondelete) {
-            self.ondelete(encounter);
+            self.ondelete(cell);
         }
     };
 
     /**
      * Fires the `onadd` callback to the responder.
      */
-    self.addEncounter = function(parent) {
+    self.addCell = function(parent) {
         if (self.onadd) {
             self.onadd(parent);
         }
     };
 
+    /* UI Methods */
+
     /**
      * Returns the correct active css for a given encounter.
      */
-    self.isActiveCSS = function(encounter) {
-        var selected = self.selectedEncounter();
+    self.isActiveCSS = function(cell) {
+        var selected = self.selectedCell();
         if (selected) {
-            return encounter.encounterId() === selected.encounterId() ? 'active' : '';
+            return cell.encounterId() === selected.encounterId() ? 'active' : '';
         }
     };
 
-    self.isSelected = function(encounter) {
-        if (!self.selectedEncounter()) { return false; }
-        return self.selectedEncounter().encounterId() === encounter.encounterId() ? true : false;
+    self.isSelected = function(cell) {
+        if (!self.selectedCell()) { return false; }
+        return self.selectedCell().id() === cell.id() ? true : false;
     };
 }
 
-ko.components.register('encounter-list', {
-    viewModel: EncounterListComponentViewModel,
+ko.components.register('nested-list', {
+    viewModel: NestedListComponentViewModel,
     template: '\
-        <div data-bind="foreach: encounters" class="list-group no-bottom-margin">\
+        <div data-bind="foreach: cells" class="list-group no-bottom-margin">\
             <a href="#" class="list-group-item" \
                 data-bind="css: $parent.isActiveCSS($data), \
-                    click: $parent.selectEncounter">\
+                    click: $parent.selectCell">\
                 <!-- ko if: $parent.levels > 0  && children().length > 0 -->\
                 <i data-bind="css: arrowIconClass, click: toggleIsOpen" aria-hidden="true"></i>&nbsp; \
                 <!-- /ko -->\
@@ -87,21 +89,21 @@ ko.components.register('encounter-list', {
                 <span class="pull-right"> \
                     <!-- ko if: $parent.levels > 0 -->\
                     <span class="glyphicon glyphicon-plus" \
-                        data-bind="click: $parent.addEncounter"></span>&nbsp;&nbsp; \
+                        data-bind="click: $parent.addCell"></span>&nbsp;&nbsp; \
                     <!-- /ko -->\
                     <span class="glyphicon glyphicon-trash" \
-                        data-bind="click: $parent.deleteEncounter"></span>\
+                        data-bind="click: $parent.deleteCell"></span>\
                 </span> \
                 <!-- /ko -->\
             </a>\
             <div class="row" data-bind="well: { open: isOpen }">\
                 <div class="col-sm-offset-1 col-sm-11">\
                     <!-- ko if: $parent.levels > 0  && children().length > 0 -->\
-                    <encounter-list params="encounters: getChildren(), \
+                    <nested-list params="cells: children, \
                         levels: $parent.levels - 1, \
-                        selectedEncounter: $parent.selectedEncounter, \
+                        selectedCell: $parent.selectedCell, \
                         onadd: $parent.onadd, \
-                        ondelete: $parent.ondelete"></encounter-list>\
+                        ondelete: $parent.ondelete"></nested-list>\
                     <!-- /ko -->\
                 </div>\
             </div>\

--- a/charactersheet/charactersheet/components/nested-list.js
+++ b/charactersheet/charactersheet/components/nested-list.js
@@ -1,22 +1,23 @@
 'use strict';
 
 /**
- * encounter-list component
+ * nested-list component
  *
- * This component uses the provided list of encounters and displays them.
- * Then handles when a given encounter has been selected.
+ * This component uses the provided list of cells and displays them.
+ * Then handles when a given cell has been selected, added, or removed.
  *
- * @param encounters {Array Encounter} A list of possible encounters.
- * @param selectedEncounter {Encounter} The observable used to store.
- * @param levels {Int} The maximum level of nested encounters to display.
+ * @param cells {Array Encounter} A list of cells. Nested cells are children
+ * of the top level cells.
+ * @param selectedCell {Encounter} The observable used to store the selected cell.
+ * @param levels {Int} The maximum level of nested cells to display.
  * the currently selected encounter. Default is 5.
  *
  * Events:
  * @param onadd {Function} A callback that takes 1 parameter. This callback is
- * invoked when a new encounter has been added. The parameter is the parent
- * of the new encounter if it exists.
+ * invoked when a new cell has been added. The parameter is the parent
+ * of the new cell if it exists.
  * @param ondelete {Function} A callback function that takes 1 parameter. The only
- * parameter is the encounter object that is to be removed.
+ * parameter is the cell object that is to be removed.
  *
  * Note: This binding recursively uses itself to render it's children.
  */

--- a/charactersheet/charactersheet/index.html
+++ b/charactersheet/charactersheet/index.html
@@ -303,6 +303,7 @@
 <script src="viewmodels/dm/overview.js" type="text/javascript"></script>
 <script src="viewmodels/dm/encounter_tab.js" type="text/javascript"></script>
 <script src="viewmodels/dm/encounter.js" type="text/javascript"></script>
+<script src="viewmodels/dm/encounter_cell.js" type="text/javascript"></script>
 <script src="viewmodels/dm/encounter_detail.js" type="text/javascript"></script>
 <script src="viewmodels/dm/encounter_section_visibility.js" type="text/javascript"></script>
 <script src="viewmodels/dm/encounter_sections/combat_section.js" type="text/javascript"></script>
@@ -373,7 +374,7 @@
 <script src="components/plus-minus.js" type="text/javascript"></script>
 <script src="components/proficiency-marker.js" type="text/javascript"></script>
 <script src="components/markdown-edit-preview.js" type="text/javascript"></script>
-<script src="components/encounter-list.js" type="text/javascript"></script>
+<script src="components/nested-list.js" type="text/javascript"></script>
 <!-- Settings -->
 <script src="settings.js" type="text/javascript"></script>
 

--- a/charactersheet/charactersheet/models/dm/encounter.js
+++ b/charactersheet/charactersheet/models/dm/encounter.js
@@ -25,7 +25,13 @@ function Encounter() {
     self.parent = ko.observable();
     self.children = ko.observableArray([]);
 
-    // Public Methods
+    /* Public Methods */
+
+    self.removeChild = function(childId) {
+        self.children(self.children().filter(function(id, idx, _) {
+            return id !== childId;
+        }));
+    };
 
     /**
      * Returns the list of encounter objects corresponding to the child ids.
@@ -34,52 +40,19 @@ function Encounter() {
         return self.children().map(function(id, idx, _) {
             return PersistenceService.findFirstBy(Encounter, 'encounterId', id);
         });
-
     };
 
-    self.toggleIsOpen = function() {
-        self.isOpen(!self.isOpen());
+    self.getParent = function() {
+        return PersistenceService.findFirstBy(Encounter, 'encounterId', self.parent());
     };
 
-    self.arrowIconClass = ko.pureComputed(function() {
-        return self.isOpen() ? 'fa fa-caret-down' : 'fa fa-caret-right';
-    });
-
-    /**
-     * If the current encounter contains a parent, then check if it's parent
-     * knows. If the parent isn't aware that it has a child, it could get really
-     * awkward at dinner-time.
-     */
-    self.alertParentOfNewChild = function() {
-        if (!self.parent()) { return; }
-        var parent = PersistenceService.findFirstBy(Encounter, 'encounterId', self.parent());
-        if (parent.children().indexOf(self.encounterId()) === -1) {
-            parent.children.push(self.encounterId());
-            parent.save();
-        }
-    };
-
-    /**
-     * If the node has a parent, remove itself from it's parent's custody.
-     */
-    self.alertParentOfLostChild = function() {
-        if (!self.parent()) { return; }
-        var parent = PersistenceService.findFirstBy(Encounter, 'encounterId', self.parent());
-        if (parent.children().indexOf(self.encounterId()) > -1) {
-            parent.children.remove(self.encounterId());
-            parent.save();
-        }
-    };
+    /* View Model Methods */
 
     self.save = function() {
         self.ps.save();
     };
 
     self.delete = function() {
-        self.alertParentOfLostChild();
-        self.getChildren().forEach(function(child, idx, _) {
-            child.delete();
-        });
         self.ps.delete();
     };
 

--- a/charactersheet/charactersheet/models/dm/encounter_sections/notes_section.js
+++ b/charactersheet/charactersheet/models/dm/encounter_sections/notes_section.js
@@ -17,7 +17,7 @@ function NotesSection() {
     self.name = ko.observable('Notes');
 
     self.notes = ko.observable('');
-    self.visible = ko.observable(false);
+    self.visible = ko.observable(true);
 
     self.save = function() {
         self.ps.save();

--- a/charactersheet/charactersheet/templates/dm/encounter.tmpl.html
+++ b/charactersheet/charactersheet/templates/dm/encounter.tmpl.html
@@ -17,10 +17,10 @@
                 </div>
               </div>
             </div>
-            <encounter-list params="encounters: encounters,
-              selectedEncounter: selectedEncounter, ondelete: deleteEncounter,
+            <nested-list params="cells: encounterCells,
+              selectedCell: selectedCell, ondelete: deleteEncounter,
               onadd: openAddModalWithParent">
-            </encounter-list>
+            </nested-list>
           </div>
         </div>
       </div>

--- a/charactersheet/charactersheet/viewmodels/dm/encounter_cell.js
+++ b/charactersheet/charactersheet/viewmodels/dm/encounter_cell.js
@@ -1,0 +1,64 @@
+'use strict';
+
+function EncounterCellViewModel(encounter) {
+    var self = this;
+
+    self.id = encounter.encounterId;
+    self.characterId = encounter.characterId;
+    self.encounterId = encounter.encounterId;
+    self.name = encounter.name;
+    self.encounterLocation = encounter.encounterLocation;
+
+    self._children = ko.observableArray(encounter.getChildren());
+    self.isOpen = encounter.isOpen;
+
+    /* UI Methods */
+
+    self.arrowIconClass = ko.pureComputed(function() {
+        return self.isOpen() ? 'fa fa-caret-down' : 'fa fa-caret-right';
+    });
+
+    self.children = ko.pureComputed(function() {
+        return self._children().map(function(child, idx, _) {
+            return new EncounterCellViewModel(child)
+        });
+    });
+
+    self.toggleIsOpen = function() {
+        self.isOpen(!self.isOpen());
+    };
+
+    /* Child Management Methods */
+
+    self.addChild = function(child) {
+        // Update the data.
+        var encounter = PersistenceService.findFirstBy(Encounter, 'encounterId', self.encounterId());
+        encounter.children.push(child.encounterId());
+        encounter.save();
+
+        // Update the UI.
+        self._children.push(child);
+    };
+
+    self.removeChild = function(child) {
+        self._children(self._children().filter(function(encounter, idx, _) {
+            return child.encounterId() !== encounter.encounterId();
+        }));
+    };
+
+    /* View Model Methods */
+
+    self.save = function() {
+        var encounter = PersistenceService.findFirstBy(Encounter, 'encounterId', self.encounterId());
+        encounter.name(self.name());
+        encounter.encounterLocation(self.encounterLocation());
+    };
+
+    self.delete = function() {
+        var encounter = PersistenceService.findFirstBy(Encounter, 'encounterId', self.encounterId());
+        encounter.delete();
+        self.children().forEach(function(child, idx, _) {
+            child.delete();
+        });
+    };
+};

--- a/test/viewmodels/dm/test_encounter.js
+++ b/test/viewmodels/dm/test_encounter.js
@@ -4,18 +4,18 @@ describe('Encounter View Model', function() {
 
     describe('Load', function() {
         it('should load the encounters list', function() {
-            var data = [new Encounter()];
+            var data = [new EncounterCellViewModel(new Encounter())];
 
             var vm = new EncounterViewModel();
-            var spy1 = simple.mock(vm, '_getTopLevelEncounters').returnWith(data);
-            var spy2 = simple.mock(vm.selectedEncounter, 'subscribe').callFn(function() {});
+            var spy1 = simple.mock(vm, '_getEncounterCells').returnWith(data);
+            var spy2 = simple.mock(vm.selectedCell, 'subscribe').callFn(function() {});
 
             spy1.called.should.equal(false);
             spy2.called.should.equal(false);
             vm.load();
             spy1.called.should.equal(true);
             spy2.called.should.equal(true);
-            vm.selectedEncounter().encounterId().should.equal(data[0].encounterId());
+            vm.selectedCell().encounterId().should.equal(data[0].encounterId());
         });
     });
 
@@ -23,43 +23,40 @@ describe('Encounter View Model', function() {
         it('should take the value from the modal and add relevant data,'
             +' then save and reload the enocunters', function() {
             simple.mock(CharacterManager, 'activeCharacter').callFn(MockCharacterManager.activeCharacter);
-            var data = [new Encounter()];
+            var data = [new EncounterCellViewModel(new Encounter())];
 
             var vm = new EncounterViewModel();
             vm.encounterDetailViewModel(new EncounterDetailViewModel(new Encounter(), []));
-            simple.mock(vm, 'modalEncounter').returnWith(data[0]);
-            var spy1 = simple.mock(vm, '_getTopLevelEncounters').returnWith(data);
+            simple.mock(vm, 'modalEncounter').returnWith(new Encounter());
+            var spy1 = simple.mock(vm, '_findCell').returnWith(data[0]);
             var spy3 = simple.mock(vm.encounterDetailViewModel(), 'save').callFn(function() {});
 
             spy1.called.should.equal(false);
             vm.addEncounter();
             spy1.called.should.equal(true);
-            vm.selectedEncounter().encounterId().should.equal(data[0].encounterId());
+            vm.selectedCell().encounterId().should.equal(data[0].encounterId());
             spy3.called.should.equal(true);
         });
 
-        it('should take the value from the modal and add relevant data,'
-            +' then save and reload the enocunters. This one has a parent', function() {
-            simple.mock(CharacterManager, 'activeCharacter').callFn(MockCharacterManager.activeCharacter);
-            var data = [new Encounter()];
-            data[0].parent(uuid.v4());
-
-            var vm = new EncounterViewModel();
-            vm.encounterDetailViewModel(new EncounterDetailViewModel(new Encounter(), []));
-            simple.mock(vm, 'modalEncounter').returnWith(data[0]);
-            var spy1 = simple.mock(vm, '_getTopLevelEncounters').returnWith(data);
-            var parentSpy = simple.mock(data[0], 'alertParentOfNewChild').callFn(function() {});
-            var spy2 = simple.mock(vm.selectedEncounter, 'subscribe').callFn(function() {});
-            var spy3 = simple.mock(vm.encounterDetailViewModel(), 'save').callFn(function() {});
-
-            spy1.called.should.equal(false);
-            parentSpy.called.should.equal(false);
-            vm.addEncounter();
-            spy1.called.should.equal(true);
-            parentSpy.called.should.equal(true);
-            vm.selectedEncounter().encounterId().should.equal(data[0].encounterId());
-            spy3.called.should.equal(true);
-        });
+//         it('should take the value from the modal and add relevant data,'
+//             +' then save and reload the enocunters. This one has a parent', function() {
+//             simple.mock(CharacterManager, 'activeCharacter').callFn(MockCharacterManager.activeCharacter);
+//             var data = [new Encounter()];
+//             data[0].parent(uuid.v4());
+//
+//             var vm = new EncounterViewModel();
+//             vm.encounterDetailViewModel(new EncounterDetailViewModel(new Encounter(), []));
+//             simple.mock(vm, 'modalEncounter').returnWith(data[0]);
+//             var spy1 = simple.mock(vm, '_findCell').returnWith(new EncounterCellViewModel(data[0]));
+//             var spy2 = simple.mock(vm.selectedCell, 'subscribe').callFn(function() {});
+//             var spy3 = simple.mock(vm.encounterDetailViewModel(), 'save').callFn(function() {});
+//
+//             spy1.called.should.equal(false);
+//             vm.addEncounter();
+//             spy1.called.should.equal(true);
+//             vm.selectedCell().encounterId().should.equal(data[0].encounterId());
+//             spy3.called.should.equal(true);
+//         });
     });
 
     describe('openAddModal', function() {
@@ -141,25 +138,6 @@ describe('Encounter View Model', function() {
             unloadSpy.called.should.equal(false);
             vm._deinitializeDetailViewModel();
             unloadSpy.called.should.equal(true);
-        });
-    });
-
-    describe('_getTopLevelEncounters', function() {
-        it('should fetch the top level encounters (encounters with a null parent', function() {
-            var enc1 = new Encounter();
-            enc1.parent(uuid.v4());
-            var enc2 = new Encounter();
-            enc2.parent(null);
-            var data = [enc1, enc2];
-
-            var vm = new EncounterViewModel();
-            simple.mock(CharacterManager, 'activeCharacter').callFn(MockCharacterManager.activeCharacter);
-            var spy = simple.mock(PersistenceService, 'findBy').returnWith(data);
-
-            spy.called.should.equal(false);
-            var result = vm._getTopLevelEncounters();
-            spy.called.should.equal(true);
-            result[0].encounterId().should.equal(data[1].encounterId())
         });
     });
 });


### PR DESCRIPTION
### Summary of Changes

- Encounters have now been divorced from their previous view-related
  activities. Encounters are now displayed via EncounterCellViewModels which
map their underlying encounter model to a view cell.
    - Doing this allows the encounter-list component to be generalized (as it
      has been) into a nested-list component that can display any cell VM that
follows it's criteria.

### Issues Fixed

Fixes #1047 
Fixes #1054 