### PR TITLE
Fixes an issue where null text would break markdown parsing.

### DIFF
--- a/charactersheet/bin/knockout-markdown.js
+++ b/charactersheet/bin/knockout-markdown.js
@@ -48,11 +48,11 @@ ko.bindingHandlers.markdownEditor = {
  */
 ko.bindingHandlers.markdownPreview = {
     init: function(element, valueAccessor, allBindings) {
-        var value = ko.unwrap(valueAccessor());
+        var value = ko.unwrap(valueAccessor()) || '';
         $(element).html(marked(value));
     },
     update: function(element, valueAccessor, allBindings) {
-        var value = ko.unwrap(valueAccessor());
+        var value = ko.unwrap(valueAccessor()) || '';
         $(element).html(marked(value));
     }
 };


### PR DESCRIPTION
### Summary of Changes

- Null values now cause empty strings to be passed to markdown parser.
- This would cause weird UI if bindings threw errors.

### Issues Fixed

None Logged.

### Changes Proposed (if any)

None

### Screen Shot of Proposed Changes (if UI related)

None
