### PR TITLE
Read Aloud text is now on by default

### DIFF
--- a/charactersheet/charactersheet/models/dm/encounter_sections/player_text_section.js
+++ b/charactersheet/charactersheet/models/dm/encounter_sections/player_text_section.js
@@ -10,7 +10,7 @@ function PlayerTextSection() {
     self.characterId = ko.observable();
     self.encounterId = ko.observable();
     self.name = ko.observable('Read-Aloud Text');
-    self.visible = ko.observable(false);
+    self.visible = ko.observable(true);
     self.tagline = ko.observable('For all the things you need to say to players: wall carvings, secret messages, or worldly descriptions.');
 
     //Public Methods


### PR DESCRIPTION
### Summary of Changes

Changed default value for player-text visibility

### Issues Fixed

Fixes #1068 

### Changes Proposed (if any)

None

### Screen Shot of Proposed Changes (if UI related)

None
