### PR TITLE
Fixes an issue where profiles would not unsubscribe from notifications

### DIFF
--- a/charactersheet/charactersheet/viewmodels/character/profile.js
+++ b/charactersheet/charactersheet/viewmodels/character/profile.js
@@ -40,9 +40,7 @@ function ProfileViewModel() {
     };
 
     self.init = function() {
-        Notifications.global.save.add(function() {
-            self.dataHasChanged();
-        });
+        Notifications.global.save.add(self.dataHasChanged);
     };
 
     self.load = function() {
@@ -79,6 +77,7 @@ function ProfileViewModel() {
 
     self.unload = function() {
         Notifications.stats.changed.remove(self.dataHasChanged);
+        Notifications.global.save.remove(self.dataHasChanged);
     };
 
     self.dataHasChanged = function() {


### PR DESCRIPTION
### Summary of Changes

- When switching from a character to DM, the profile module should unsubscribe from notifications, since it missed 1, it would get notified to save data incorrectly. This caused errors when exporting DMs.

### Issues Fixed

Fixes #1067 

### Changes Proposed (if any)

We must be sure to unsubscribe from all notifications in the VM `unload` method.

### Screen Shot of Proposed Changes (if UI related)

None.
