### PR TITLE
Add magic damage types to options list for weapons

### DIFF
--- a/charactersheet/charactersheet/utilities/fixtures.js
+++ b/charactersheet/charactersheet/utilities/fixtures.js
@@ -239,9 +239,19 @@ var Fixtures = {
     weapon: {
         weaponDamageTypeOptions: [
             '',
+            'Acid',
             'Bludgeoning',
+            'Cold',
+            'Fire',
+            'Force',
+            'Lightning',
+            'Necrotic',
             'Piercing',
-            'Slashing'
+            'Poison',
+            'Psychic',
+            'Radiant',
+            'Slashing',
+            'Thunder'
         ],
         weaponHandednessOptions: [
             'One or Two Handed',


### PR DESCRIPTION
### Summary of Changes

Add magic damage types to options list for weapons

### Issues Fixed

Fixes #1108 

### Screen Shot of Proposed Changes (if UI related)

<img width="370" alt="screen shot 2017-01-05 at 5 49 19 am" src="https://cloud.githubusercontent.com/assets/5814150/21682744/0c97f3ba-d30b-11e6-9580-da807bce0513.png">

