### PR TITLE
Convert trashcans and plus icons to font awesome for consistency

### DIFF
--- a/charactersheet/charactersheet/components/nested-list.js
+++ b/charactersheet/charactersheet/components/nested-list.js
@@ -92,7 +92,7 @@ ko.components.register('nested-list', {
                     <span class="fa fa-plus fa-lg" \
                         data-bind="click: $parent.addCell"></span>&nbsp;&nbsp; \
                     <!-- /ko -->\
-                    <span class="fa fa-trash-o fa-color-hover fa-lg" \
+                    <span class="fa fa-trash-o fa-color-white-hover fa-lg" \
                         data-bind="click: $parent.deleteCell"></span>\
                 </span> \
                 <!-- /ko -->\

--- a/charactersheet/charactersheet/components/nested-list.js
+++ b/charactersheet/charactersheet/components/nested-list.js
@@ -89,10 +89,10 @@ ko.components.register('nested-list', {
                 <!-- ko if: $parent.isSelected($data) -->\
                 <span class="pull-right"> \
                     <!-- ko if: $parent.levels > 0 -->\
-                    <span class="glyphicon glyphicon-plus" \
+                    <span class="fa fa-plus fa-lg" \
                         data-bind="click: $parent.addCell"></span>&nbsp;&nbsp; \
                     <!-- /ko -->\
-                    <span class="glyphicon glyphicon-trash glyphicon-trash-hover" \
+                    <span class="fa fa-trash-o fa-color-hover fa-lg" \
                         data-bind="click: $parent.deleteCell"></span>\
                 </span> \
                 <!-- /ko -->\

--- a/charactersheet/charactersheet/templates/character/notes.tmpl.html
+++ b/charactersheet/charactersheet/templates/character/notes.tmpl.html
@@ -16,7 +16,7 @@
             <span data-bind="html: headline"></span>
             <!-- ko if: $parent.isActiveCSS($data) == 'active' -->
             <div class="pull-right">
-              <span class="fa fa-trash-o fa-color-hover fa-lg"
+              <span class="fa fa-trash-o fa-color-white-hover fa-lg"
                 data-bind="click: $parent.deleteNote"></span>
             </div>
             <!-- /ko -->

--- a/charactersheet/charactersheet/templates/character/notes.tmpl.html
+++ b/charactersheet/charactersheet/templates/character/notes.tmpl.html
@@ -5,7 +5,7 @@
         <div class="h4">
           All Notes
           <div class="pull-right">
-              <span class="glyphicon glyphicon-plus" style="cursor:pointer;"
+              <span class="fa fa-plus" style="cursor:pointer;"
                 data-bind="click: addNote"></span>
             </div>
           </div>
@@ -16,7 +16,7 @@
             <span data-bind="html: headline"></span>
             <!-- ko if: $parent.isActiveCSS($data) == 'active' -->
             <div class="pull-right">
-              <span class="glyphicon glyphicon-trash"
+              <span class="fa fa-trash-o fa-color-hover fa-lg"
                 data-bind="click: $parent.deleteNote"></span>
             </div>
             <!-- /ko -->

--- a/charactersheet/charactersheet/templates/dm/encounter.tmpl.html
+++ b/charactersheet/charactersheet/templates/dm/encounter.tmpl.html
@@ -12,7 +12,7 @@
               <div class="h4">
                 Encounters
                 <div class="pull-right">
-                  <span class="glyphicon glyphicon-plus" style="cursor:pointer;"
+                  <span class="fa fa-plus fa-lg" style="cursor:pointer;"
                     data-bind="click: openAddModal"></span>
                 </div>
               </div>

--- a/charactersheet/site.css
+++ b/charactersheet/site.css
@@ -344,9 +344,17 @@ textarea.dark-area {
   color:#e74c3c;
 }
 
-.glyphicon-trash-hover:hover {
+.fa-color-white-hover {
+  color:#ffffff;
+}
+
+.fa-color-white-hover:hover {
   color:#e74c3c;
 }
+
+/*.glyphicon-trash-hover:hover {
+  color:#e74c3c;
+}*/
 
 .feature-row span {
   line-height: 3em;

--- a/charactersheet/site.css
+++ b/charactersheet/site.css
@@ -352,10 +352,6 @@ textarea.dark-area {
   color:#e74c3c;
 }
 
-/*.glyphicon-trash-hover:hover {
-  color:#e74c3c;
-}*/
-
 .feature-row span {
   line-height: 3em;
 }


### PR DESCRIPTION
### Summary of Changes

Convert trashcans and plus icons to font awesome for consistency.  This also converts the player character notes module icons too.

### Issues Fixed

Fixes #1085 

### Screen Shot of Proposed Changes (if UI related)

<img width="396" alt="screen shot 2017-01-10 at 6 05 02 am" src="https://cloud.githubusercontent.com/assets/5814150/21809078/0744fd1a-d6fb-11e6-9869-d319de9bb3ab.png">

<img width="302" alt="screen shot 2017-01-10 at 6 04 44 am" src="https://cloud.githubusercontent.com/assets/5814150/21809083/0ae66aee-d6fb-11e6-83d5-551f14901b10.png">


