### PR TITLE
Remove min from proficiency bonus adjustment element

### DIFF
--- a/charactersheet/charactersheet/templates/character/other_stats.tmpl.html
+++ b/charactersheet/charactersheet/templates/character/other_stats.tmpl.html
@@ -10,7 +10,7 @@
      <div class="input-group">
        <span class="input-group-addon" id="basic-addon2">Proficiency Bonus </span>
        <span class="input-group-addon" id="basic-addon3" data-bind="text: otherStats().proficiencyLabel"></span>
-       <input type="number" class="form-control" aria-describedby="basic-addon2" data-bind='textInput: otherStats().proficiency' min="0">
+       <input type="number" class="form-control" aria-describedby="basic-addon2" data-bind='textInput: otherStats().proficiency'>
      </div>
    </div>
  </div>


### PR DESCRIPTION
### Summary of Changes

Remove min from proficiency bonus adjustment element

### Issues Fixed

Fixes #1138 

### Screen Shot of Proposed Changes (if UI related)

<img width="390" alt="screen shot 2017-01-16 at 1 04 27 pm" src="https://cloud.githubusercontent.com/assets/5814150/21998973/94ce7b3e-dbec-11e6-97d6-c9a2cd9fd5e9.png">


