### PR TITLE
Set min to 0 for spell level for spell edit modal

### DIFF
--- a/charactersheet/charactersheet/templates/character/spells.tmpl.html
+++ b/charactersheet/charactersheet/templates/character/spells.tmpl.html
@@ -385,7 +385,7 @@
                         <input type="number"
                                class="form-control"
                                id="spellLevel"
-                               min="1"
+                               min="0"
                                max="9"
                                placeholder="1"
                                data-bind="value: spellLevel">


### PR DESCRIPTION
### Summary of Changes

Set min to 0 for spell level for spell edit modal

### Issues Fixed

Fixes #1157

### Screen Shot of Proposed Changes (if UI related)

![screen shot 2017-01-22 at 1 20 33 pm](https://cloud.githubusercontent.com/assets/5814150/22186129/ab23a0c2-e0a5-11e6-83f8-d9b30f6d3af6.png)

