### PR TITLE
Spell slots field focus

### DIFF
--- a/charactersheet/charactersheet/models/character/spell_slot.js
+++ b/charactersheet/charactersheet/models/character/spell_slot.js
@@ -11,7 +11,7 @@ function Slot() {
 
     self.characterId = ko.observable(null);
     self.level = ko.observable(1);
-    self.maxSpellSlots = ko.observable(1);
+    self.maxSpellSlots = ko.observable();
     self.usedSpellSlots = ko.observable(0);
     self.resetsOn = ko.observable();
 

--- a/charactersheet/charactersheet/templates/character/spell_slots.tmpl.html
+++ b/charactersheet/charactersheet/templates/character/spell_slots.tmpl.html
@@ -79,13 +79,14 @@
 						<label for="name" class="col-sm-2 control-label">Level</label>
 						<div class="col-sm-10">
 							<input type="number" class="form-control" id="level" min="1" max="9"
-								data-bind='textInput: blankSlot().level, hasFocus: modifierHasFocus'>
+								data-bind='textInput: blankSlot().level'>
 						</div>
 					</div>
 					<div class="form-group">
 						<label for="bonus" class="col-sm-2 control-label">Max</label>
 						<div class="col-sm-10">
-							<input type="number" class="form-control" id="max" min="1" max="4" data-bind='textInput: blankSlot().maxSpellSlots'>
+							<input type="number" class="form-control" id="max" min="1" max="4"
+                data-bind='textInput: blankSlot().maxSpellSlots, hasFocus: modifierHasFocus'>
 						</div>
 					</div>
           <div class="form-group">
@@ -97,14 +98,16 @@
                    <input type="radio" class="hide-block"
                    name="blankresetsOnShort" value="short"
                    data-bind="checked: blankSlot().resetsOn"/>
-                   Short Rest
+                    <img class="action-bar-icon" src="/images/meditation.svg"></img>
+                    &nbsp;&nbsp;&nbsp;Short Rest
                 </label>
                 <label class="btn btn-default"
                  data-bind="css: { active: blankSlot().resetsOn() != 'short'}">
                    <input type="radio" class="hide-block"
                    name="blankresetsOnLong" value="long"
                    data-bind="checked: blankSlot().resetsOn"/>
-                   Long Rest
+                   <img class="action-bar-icon" src="/images/camping-tent.svg"></img>
+								    &nbsp;&nbsp;&nbsp;Long Rest
                 </label>
               </div>
             </div>
@@ -139,13 +142,14 @@
 							<label for="name" class="col-sm-2 control-label">Level</label>
 							<div class="col-sm-10">
 								<input type="number" class="form-control" id="name" min="1" max="9"
-									data-bind="value: level, hasFocus: $parent.editHasFocus">
+									data-bind="value: level">
 							</div>
 						</div>
 						<div class="form-group">
 							<label for="bonus" class="col-sm-2 control-label">Max</label>
 							<div class="col-sm-10">
-								<input type="number" class="form-control" id="bonus" min="1" max="4" data-bind="value: maxSpellSlots">
+								<input type="number" class="form-control" id="bonus" min="1" max="4"
+                  data-bind="value: maxSpellSlots, hasFocus: $parent.editHasFocus">
 							</div>
 						</div>
            <div class="form-group">
@@ -156,13 +160,15 @@
                  data-bind="css: { active: resetsOn() == 'short'}">
                    <input type="radio" class="hide-block"
                    name="resetsOnShort" value="short" data-bind="checked: resetsOn"/>
-                   Short Rest
+                   <img class="action-bar-icon" src="/images/meditation.svg"></img>
+                   &nbsp;&nbsp;&nbsp;Short Rest
                  </label>
                  <label class="btn btn-default"
                  data-bind="css: { active: resetsOn() != 'short'}">
-                   <input type="radio" class="hide-block"
-                   name="resetsOnLong" value="long" data-bind="checked: resetsOn"/>
-                   Long Rest
+                    <input type="radio" class="hide-block"
+                    name="resetsOnLong" value="long" data-bind="checked: resetsOn"/>
+                    <img class="action-bar-icon" src="/images/camping-tent.svg"></img>
+                    &nbsp;&nbsp;&nbsp;Long Rest
                  </label>
                </div>
              </div>

--- a/charactersheet/charactersheet/viewmodels/character/spell_slots.js
+++ b/charactersheet/charactersheet/viewmodels/character/spell_slots.js
@@ -30,9 +30,7 @@ function SpellSlotsViewModel() {
         var slots = PersistenceService.findBy(Slot, 'characterId',
             CharacterManager.activeCharacter().key());
         self.slots(slots);
-
         self.blankSlot().level(self.slots().length + 1);
-        self.blankSlot().maxSpellSlots(1);
 
         //Notifications
         Notifications.events.longRest.add(self.resetOnLongRest);
@@ -135,12 +133,12 @@ function SpellSlotsViewModel() {
 
         self.blankSlot(new Slot());
         self.blankSlot().level(self.slots().length + 1);
-        self.blankSlot().maxSpellSlots(1);
     };
 
     self.removeSlot = function(slot) {
         self.slots.remove(slot);
         slot.delete();
+        self.blankSlot().level(self.slots().length + 1);
     };
 
     self.resetSlots = function() {
@@ -151,14 +149,14 @@ function SpellSlotsViewModel() {
 
     self.increaseUsage = function(spellSlots) {
         var used = spellSlots.usedSpellSlots();
-        if(used !== parseInt(spellSlots.maxSpellSlots())){
+        if (used !== parseInt(spellSlots.maxSpellSlots())) {
             spellSlots.usedSpellSlots(used + 1);
         }
     };
 
     self.decreaseUsage = function(spellSlots) {
         var used = spellSlots.usedSpellSlots();
-        if(used !== 0){
+        if (used !== 0) {
             spellSlots.usedSpellSlots(used - 1);
         }
     };

--- a/test/models/test_slots.js
+++ b/test/models/test_slots.js
@@ -22,7 +22,7 @@ describe('Slot Model', function() {
             s.usedSpellSlots().should.equal(1);
             s.clear();
             s.level().should.equal(1);
-            s.maxSpellSlots().should.equal(1);
+            Should.not.exist(s.maxSpellSlots());
             s.usedSpellSlots().should.equal(0);
         });
     });

--- a/test/viewmodels/test_spell_slots.js
+++ b/test/viewmodels/test_spell_slots.js
@@ -81,6 +81,11 @@ describe('Spell Slots View Model', function() {
             p.addSlot();
             p.addSlot();
             p.addSlot();
+
+            p.slots().forEach(function(slot, idx, _) {
+                slot.maxSpellSlots(1);
+            });
+
             p.currentSlotWidth(1,1).should.equal('25%');
 
             CharacterManager.activeCharacter = c;


### PR DESCRIPTION
### Summary of Changes

* Changed initial modal focus to max slots in add/edit. 
* Somewhat fixed "auto-spell-slot-level-calculation."
* Removed default value from maxSlot, since it would always get overwritten anyway.
* Added short/long rest icons to spell slots.

### Issues Fixed

Fixes #1106

### Screen Shot of Proposed Changes (if UI related)

![image](https://cloud.githubusercontent.com/assets/7286387/22319677/cd9dd690-e339-11e6-9c8e-1b60e0d32b8c.png)
