### PR TITLE
Fix UI on Spell Slots to match Tracked Features

### DIFF
--- a/charactersheet/charactersheet/models/character/spell_slot.js
+++ b/charactersheet/charactersheet/models/character/spell_slot.js
@@ -13,7 +13,7 @@ function Slot() {
     self.level = ko.observable(1);
     self.maxSpellSlots = ko.observable();
     self.usedSpellSlots = ko.observable(0);
-    self.resetsOn = ko.observable();
+    self.resetsOn = ko.observable('long');
 
     self.color = ko.pureComputed(function() {
         return self.slotColors[self.level()-1];

--- a/charactersheet/charactersheet/templates/character/spell_slots.tmpl.html
+++ b/charactersheet/charactersheet/templates/character/spell_slots.tmpl.html
@@ -8,30 +8,30 @@
     <table id='spellSlotsTable' class="table table-responsive table-ac-bordered table-hover">
       <thead>
         <tr class="row">
-          <th class="col-sm-1">Slot</th>
-          <th class="col-sm-2 hidden-xs" data-bind="click: function(){sortBy('level');}">Level
+          <th class="col-sm-1 col-xs-1">Slot</th>
+          <th class="col-sm-2 col-xs-2" data-bind="click: function(){sortBy('level');}">Level
             <i data-bind="css: sortArrow('level')"></i></th>
           <th class="col-sm-2 hidden-xs" data-bind="click: function(){sortBy('maxSpellSlots');}">Max
             <i data-bind="css: sortArrow('maxSpellSlots')"></i></th>
-          <th class="col-sm-2 hidden-sm hidden-xs" data-bind="click: function(){sortBy('resetsOn');}">Resets on
+          <th class="col-md-2 hidden-sm hidden-xs" data-bind="click: function(){sortBy('resetsOn');}">Resets on
             <i data-bind="css: sortArrow('resetsOn')"></i></th>
-          <th class="col-sm-3 text-center" data-bind="click: function(){sortBy('usedSpellSlots');}">Used
+          <th class="col-md-3 col-sm-4 col-xs-8 text-center" data-bind="click: function(){sortBy('usedSpellSlots');}">Used
             <i data-bind="css: sortArrow('usedSpellSlots')"></i></th>
-          <th class="col-xs-1">Reset</th>
-          <th class="col-sm-1"> <a data-toggle="modal" data-target="#addSpellSlot" href="#"><i class="fa fa-plus fa-color"></i></a></th>
+          <th class="col-md-1 hidden-sm hidden-xs">Reset</th>
+          <th class="col-xs-1"> <a data-toggle="modal" data-target="#addSpellSlot" href="#"><i class="fa fa-plus fa-color"></i></a></th>
         </tr>
       </thead>
       <tbody>
       <!-- ko foreach: filteredAndSortedSlots -->
         <tr class="row clickable">
-          <td class="col-sm-1 col-content-vertical" data-bind="click: $parent.editSlot"
+          <td class="col-sm-1 col-xs-1 col-content-vertical" data-bind="click: $parent.editSlot"
               href="#"
               data-toggle="modal"
               data-target="#viewSlot">
             <span data-bind="css: color" class="form-control color-picker-item" >
             </span>
           </td>
-          <td class="col-sm-2 hidden-xs col-content-vertical"
+          <td class="col-sm-2 col-xs-2 col-content-vertical"
               data-bind="click: $parent.editSlot, text: level"
               href="#"
               data-toggle="modal"
@@ -43,7 +43,7 @@
               data-toggle="modal"
               data-target="#viewSlot">
           </td>
-          <td class="col-content-vertical col-sm-2 hidden-sm hidden-xs"
+          <td class="col-content-vertical col-md-2 hidden-sm hidden-xs"
               data-bind="click: $parent.editSlot"
               href="#"
               data-toggle="modal"
@@ -53,17 +53,17 @@
             </img>
             <!-- /ko -->
           </td>
-          <td class="col-sm-3">
+          <td class="col-md-3 col-sm-4 col-xs-8">
             <plus-minus params="value: usedSpellSlots,
               max: maxSpellSlots">
             </plus-minus>
           </td>
-          <td class="col-content-vertical col-xs-1 text-center"> <!--Refresh -->
+          <td class="col-content-vertical col-md-1 hidden-sm hidden-xs text-center"> <!--Refresh -->
             <a data-bind="click: $parent.resetSlot" href="#">
               <i class="fa fa-refresh fa-color"></i>
             </a>
           </td>
-          <td class="col-content-vertical">
+          <td class="col-content-vertical col-xs-1">
             <a data-bind="click: $parent.removeSlot" href="#">
               <i class="fa fa-trash-o fa-color-hover"></i>
             </a>

--- a/charactersheet/charactersheet/templates/character/spell_slots.tmpl.html
+++ b/charactersheet/charactersheet/templates/character/spell_slots.tmpl.html
@@ -25,42 +25,47 @@
       <!-- ko foreach: filteredAndSortedSlots -->
         <tr class="row clickable">
           <td class="col-sm-1 col-content-vertical" data-bind="click: $parent.editSlot"
-          href="#"
-          data-toggle="modal"
-          data-target="#viewSlot">
+              href="#"
+              data-toggle="modal"
+              data-target="#viewSlot">
             <span data-bind="css: color" class="form-control color-picker-item" >
             </span>
           </td>
           <td class="col-sm-1 col-content-vertical"
-          data-bind="click: $parent.editSlot, text: level"
-          href="#"
-          data-toggle="modal"
-          data-target="#viewSlot"></td>
+              data-bind="click: $parent.editSlot, text: level"
+              href="#"
+              data-toggle="modal"
+              data-target="#viewSlot">
+          </td>
           <td class="col-sm-1 col-content-vertical"
-            data-bind="click: $parent.editSlot, text: maxSpellSlots"
-            href="#"
-            data-toggle="modal"
-            data-target="#viewSlot"></td>
-          <td class="col-content-vertical col-sm-1 hidden-sm hidden-xs" data-bind="click: $parent.editSlot"
-          href="#"
-          data-toggle="modal"
-          data-target="#viewSlot">
+              data-bind="click: $parent.editSlot, text: maxSpellSlots"
+              href="#"
+              data-toggle="modal"
+              data-target="#viewSlot">
+          </td>
+          <td class="col-content-vertical col-sm-1 hidden-sm hidden-xs"
+              data-bind="click: $parent.editSlot"
+              href="#"
+              data-toggle="modal"
+              data-target="#viewSlot">
             <!-- ko if: $parent.needsResetsOnImg($data) -->
-            <img class="action-bar-icon" data-bind="attr: { 'src': $parent.resetsOnImgSource($data) }"></img>
+            <img class="action-bar-icon" data-bind="attr: { 'src': $parent.resetsOnImgSource($data) }">
+            </img>
             <!-- /ko -->
           </td>
           <td class="col-sm-4">
             <plus-minus params="value: usedSpellSlots,
-              max: maxSpellSlots"></plus-minus>
+              max: maxSpellSlots">
+            </plus-minus>
           </td>
           <td class="col-content-vertical col-xs-1 text-center"> <!--Refresh -->
             <a data-bind="click: $parent.resetSlots" href="#">
-              <i class="fa fa-refresh fa-color"> </i>
+              <i class="fa fa-refresh fa-color"></i>
             </a>
           </td>
           <td class="col-content-vertical">
             <a data-bind="click: $parent.removeSlot" href="#">
-              <i class="fa fa-trash-o fa-color-hover"> </i>
+              <i class="fa fa-trash-o fa-color-hover"></i>
             </a>
           </td>
         </tr>
@@ -76,8 +81,8 @@
       <!-- /ko -->
       </tbody>
     </table>
-  </div>
-</div>
+  </div> <!-- end panel-body -->
+</div> <!-- end panel -->
 
 <!-- Add Modal -->
 <div class="modal fade" id="addSpellSlot" tabindex="-1" role="dialog"
@@ -86,8 +91,12 @@
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span> </button>
+        <button type="button"
+                class="close"
+                data-dismiss="modal"
+                aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
         <h4 class="modal-title" id="addSkillLabel">
           Add a spell slot.
         </h4>
@@ -97,15 +106,23 @@
           <div class="form-group">
             <label for="name" class="col-sm-2 control-label">Level</label>
             <div class="col-sm-10">
-              <input type="number" class="form-control" id="level" min="1" max="9"
-                data-bind='textInput: blankSlot().level'>
+              <input type="number"
+                     class="form-control"
+                     id="level"
+                     min="1"
+                     max="9"
+                     data-bind='textInput: blankSlot().level'>
             </div>
           </div>
           <div class="form-group">
             <label for="bonus" class="col-sm-2 control-label">Max</label>
             <div class="col-sm-10">
-              <input type="number" class="form-control" id="max" min="1" max="4"
-                data-bind='textInput: blankSlot().maxSpellSlots, hasFocus: modifierHasFocus'>
+              <input type="number"
+                     class="form-control"
+                     id="max"
+                     min="1"
+                     max="4"
+                     data-bind='textInput: blankSlot().maxSpellSlots, hasFocus: modifierHasFocus'>
             </div>
           </div>
           <div class="form-group">
@@ -113,96 +130,123 @@
             <div class="col-sm-10">
               <div class="btn-group btn-group-justified" role="group">
                 <label class="btn btn-default"
-                 data-bind="css: { active: blankSlot().resetsOn() == 'short'}">
-                   <input type="radio" class="hide-block"
-                   name="blankresetsOnShort" value="short"
-                   data-bind="checked: blankSlot().resetsOn"/>
+                       data-bind="css: { active: blankSlot().resetsOn() == 'short'}">
+                   <input type="radio"
+                          class="hide-block"
+                          name="blankresetsOnShort" value="short"
+                          data-bind="checked: blankSlot().resetsOn"/>
                     <img class="action-bar-icon" src="/images/meditation.svg"></img>
                     &nbsp;&nbsp;&nbsp;Short Rest
                 </label>
                 <label class="btn btn-default"
                  data-bind="css: { active: blankSlot().resetsOn() != 'short'}">
-                   <input type="radio" class="hide-block"
-                   name="blankresetsOnLong" value="long"
-                   data-bind="checked: blankSlot().resetsOn"/>
+                   <input type="radio"
+                          class="hide-block"
+                          name="blankresetsOnLong"
+                          value="long"
+                          data-bind="checked: blankSlot().resetsOn"/>
                    <img class="action-bar-icon" src="/images/camping-tent.svg"></img>
                     &nbsp;&nbsp;&nbsp;Long Rest
                 </label>
               </div>
             </div>
-          </div>
+          </div> <!-- end form-group -->
           <div class="modal-footer">
-            <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button> <button type="button" class="btn btn-primary" data-bind='click: addSlot' data-dismiss="modal">Add</button>
+            <button type="button"
+                    class="btn btn-default"
+                    data-dismiss="modal">Cancel
+            </button>
+            <button type="button"
+                    class="btn btn-primary"
+                    data-bind='click: addSlot'
+                    data-dismiss="modal">Add
+            </button>
           </div>
         </form>
-      </div>
-
-<!-- Modal Body -->
-    </div>
-<!-- Modal Content -->
-  </div>
-<!-- Modal Dialog -->
-</div>
-<!-- Modal Fade -->
+      </div> <!-- end modal-body -->
+    </div> <!-- end modal content -->
+  </div> <!-- end modal dialog -->
+</div> <!-- end modal -->
 <!-- ViewEdit Modal -->
-  <div class="modal fade" id="viewSlot" tabindex="-1" role="dialog"
-    aria-labelledby="viewSlotLabel" data-bind="modal: {
-       onopen: editModalOpen}, with: selecteditem">
-    <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close"> <span aria-hidden="true">&times;</span> </button>
-          <h4 class="modal-title" id="addSlotLabel"> Edit your Spell Slot.
-          </h4>
-        </div>
-        <div class="modal-body">
-          <form class="form-horizontal">
-            <div class="form-group">
-              <label for="name" class="col-sm-2 control-label">Level</label>
-              <div class="col-sm-10">
-                <input type="number" class="form-control" id="name" min="1" max="9"
-                  data-bind="value: level">
-              </div>
-            </div>
-            <div class="form-group">
-              <label for="bonus" class="col-sm-2 control-label">Max</label>
-              <div class="col-sm-10">
-                <input type="number" class="form-control" id="bonus" min="1" max="4"
-                  data-bind="value: maxSpellSlots, hasFocus: $parent.editHasFocus">
-              </div>
-            </div>
-           <div class="form-group">
-           <label class="col-sm-2 control-label">Resets on...</label>
-             <div class="col-sm-10">
-               <div class="btn-group btn-group-justified" role="group">
-                 <label class="btn btn-default"
-                 data-bind="css: { active: resetsOn() == 'short'}">
-                   <input type="radio" class="hide-block"
-                   name="resetsOnShort" value="short" data-bind="checked: resetsOn"/>
-                   <img class="action-bar-icon" src="/images/meditation.svg"></img>
-                   &nbsp;&nbsp;&nbsp;Short Rest
-                 </label>
-                 <label class="btn btn-default"
-                 data-bind="css: { active: resetsOn() != 'short'}">
-                    <input type="radio" class="hide-block"
-                    name="resetsOnLong" value="long" data-bind="checked: resetsOn"/>
-                    <img class="action-bar-icon" src="/images/camping-tent.svg"></img>
-                    &nbsp;&nbsp;&nbsp;Long Rest
-                 </label>
-               </div>
-             </div>
-           </div>
-          </div>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-primary" data-dismiss="modal">Done</button>
-          </div>
-        </form>
+<div class="modal fade"
+     id="viewSlot"
+     tabindex="-1"
+     role="dialog"
+     aria-labelledby="viewSlotLabel"
+     data-bind="modal: {
+     onopen: editModalOpen}, with: selecteditem">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button"
+                class="close"
+                data-dismiss="modal"
+                aria-label="Close"><span aria-hidden="true">&times;</span>
+        </button>
+        <h4 class="modal-title" id="addSlotLabel"> Edit your Spell Slot.
+        </h4>
       </div>
-
-<!-- Modal Body -->
-    </div>
-<!-- Modal Content -->
-  </div>
-<!-- Modal Dialog -->
-</div>
-<!-- End with statement -->
+      <div class="modal-body">
+        <form class="form-horizontal">
+          <div class="form-group">
+            <label for="name" class="col-sm-2 control-label">Level</label>
+            <div class="col-sm-10">
+              <input type="number"
+                     class="form-control"
+                     id="name"
+                     min="1"
+                     max="9"
+                     data-bind="value: level">
+            </div>
+          </div>
+          <div class="form-group">
+            <label for="bonus" class="col-sm-2 control-label">Max</label>
+            <div class="col-sm-10">
+              <input type="number"
+                     class="form-control"
+                     id="bonus"
+                     min="1"
+                     max="4"
+                     data-bind="value: maxSpellSlots, hasFocus: $parent.editHasFocus">
+            </div>
+          </div>
+          <div class="form-group">
+          <label class="col-sm-2 control-label">Resets on...</label>
+            <div class="col-sm-10">
+              <div class="btn-group btn-group-justified" role="group">
+                <label class="btn btn-default"
+                       data-bind="css: { active: resetsOn() == 'short'}">
+                  <input type="radio"
+                         class="hide-block"
+                         name="resetsOnShort"
+                         value="short"
+                         data-bind="checked: resetsOn"/>
+                  <img class="action-bar-icon"
+                       src="/images/meditation.svg"></img>
+                       &nbsp;&nbsp;&nbsp;Short Rest
+                </label>
+                <label class="btn btn-default"
+                       data-bind="css: { active: resetsOn() != 'short'}">
+                <input type="radio"
+                       class="hide-block"
+                       name="resetsOnLong"
+                       value="long"
+                       data-bind="checked: resetsOn"/>
+                <img class="action-bar-icon"
+                     src="/images/camping-tent.svg"></img>
+                     &nbsp;&nbsp;&nbsp;Long Rest
+                </label>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button"
+                  class="btn btn-primary"
+                  data-dismiss="modal">Done</button>
+        </div>
+        </form>
+    </div> <!-- end modal body -->
+    </div> <!-- end modal content -->
+  </div> <!-- end modal dialog -->
+</div> <!-- end with statement -->

--- a/charactersheet/charactersheet/templates/character/spell_slots.tmpl.html
+++ b/charactersheet/charactersheet/templates/character/spell_slots.tmpl.html
@@ -8,14 +8,14 @@
     <table id='spellSlotsTable' class="table table-responsive table-ac-bordered table-hover">
       <thead>
         <tr class="row">
-          <th class="col-sm-3">Spell Slots</th>
-          <th class="col-sm-1" data-bind="click: function(){sortBy('level');}">Level
+          <th class="col-sm-1">Slot</th>
+          <th class="col-sm-2 hidden-xs" data-bind="click: function(){sortBy('level');}">Level
             <i data-bind="css: sortArrow('level')"></i></th>
-          <th class="col-sm-1" data-bind="click: function(){sortBy('maxSpellSlots');}">Max
+          <th class="col-sm-2 hidden-xs" data-bind="click: function(){sortBy('maxSpellSlots');}">Max
             <i data-bind="css: sortArrow('maxSpellSlots')"></i></th>
-          <th class="col-sm-1 hidden-sm hidden-xs" data-bind="click: function(){sortBy('resetsOn');}">Resets on
+          <th class="col-sm-2 hidden-sm hidden-xs" data-bind="click: function(){sortBy('resetsOn');}">Resets on
             <i data-bind="css: sortArrow('resetsOn')"></i></th>
-          <th class="col-sm-4 text-center" data-bind="click: function(){sortBy('usedSpellSlots');}">Used
+          <th class="col-sm-3 text-center" data-bind="click: function(){sortBy('usedSpellSlots');}">Used
             <i data-bind="css: sortArrow('usedSpellSlots')"></i></th>
           <th class="col-xs-1">Reset</th>
           <th class="col-sm-1"> <a data-toggle="modal" data-target="#addSpellSlot" href="#"><i class="fa fa-plus fa-color"></i></a></th>
@@ -31,19 +31,19 @@
             <span data-bind="css: color" class="form-control color-picker-item" >
             </span>
           </td>
-          <td class="col-sm-1 col-content-vertical"
+          <td class="col-sm-2 hidden-xs col-content-vertical"
               data-bind="click: $parent.editSlot, text: level"
               href="#"
               data-toggle="modal"
               data-target="#viewSlot">
           </td>
-          <td class="col-sm-1 col-content-vertical"
+          <td class="col-sm-2 hidden-xs col-content-vertical"
               data-bind="click: $parent.editSlot, text: maxSpellSlots"
               href="#"
               data-toggle="modal"
               data-target="#viewSlot">
           </td>
-          <td class="col-content-vertical col-sm-1 hidden-sm hidden-xs"
+          <td class="col-content-vertical col-sm-2 hidden-sm hidden-xs"
               data-bind="click: $parent.editSlot"
               href="#"
               data-toggle="modal"
@@ -53,13 +53,13 @@
             </img>
             <!-- /ko -->
           </td>
-          <td class="col-sm-4">
+          <td class="col-sm-3">
             <plus-minus params="value: usedSpellSlots,
               max: maxSpellSlots">
             </plus-minus>
           </td>
           <td class="col-content-vertical col-xs-1 text-center"> <!--Refresh -->
-            <a data-bind="click: $parent.resetSlots" href="#">
+            <a data-bind="click: $parent.resetSlot" href="#">
               <i class="fa fa-refresh fa-color"></i>
             </a>
           </td>

--- a/charactersheet/charactersheet/templates/character/spell_slots.tmpl.html
+++ b/charactersheet/charactersheet/templates/character/spell_slots.tmpl.html
@@ -1,33 +1,39 @@
 <div class="panel panel-default">
-	<div class='panel-body'>
-		<div class="progress" data-bind="{ foreach: slots, visible: slots().length > 0 }">
-			<div class="progress-bar" role="progressbar" aria-valuemin="0" data-bind="style: { width: $parent.currentSlotWidth(progressWidth(),maxSpellSlots()) }, css: color">
-				<span class="sr-only"></span>
-			</div>
-		</div>
-		<table id='spellSlotsTable' class="table table-responsive table-ac-bordered table-hover">
-			<thead>
-				<tr class="row">
-					<th class="col-sm-3">Spell Slots</th>
-          <th class="col-sm-1">Level</th>
-          <th class="col-sm-1">Max</th>
-					<th class="col-sm-6 text-center">Used <a class="pull-right" href="#" data-bind="click: resetSlots"><i class="fa fa-refresh fa-color"></i> </a></th>
-					<th class="col-sm-1"> <a data-toggle="modal" data-target="#addSpellSlot" href="#"> <i class="fa fa-plus fa-color"></i> </a> </th>
-				</tr>
-			</thead>
-			<tbody>
-			<!-- ko foreach: filteredAndSortedSlots -->
-				<tr class="row clickable">
-					<td class="col-sm-1 col-content-vertical" data-bind="click: $parent.editSlot"
-					href="#"
+  <div class='panel-body'>
+    <div class="progress" data-bind="{ foreach: slots, visible: slots().length > 0 }">
+      <div class="progress-bar" role="progressbar" aria-valuemin="0" data-bind="style: { width: $parent.currentSlotWidth(progressWidth(),maxSpellSlots()) }, css: color">
+        <span class="sr-only"></span>
+      </div>
+    </div>
+    <table id='spellSlotsTable' class="table table-responsive table-ac-bordered table-hover">
+      <thead>
+        <tr class="row">
+          <th class="col-sm-3">Spell Slots</th>
+          <th class="col-sm-1" data-bind="click: function(){sortBy('level');}">Level
+            <i data-bind="css: sortArrow('level')"></i></th>
+          <th class="col-sm-1" data-bind="click: function(){sortBy('maxSpellSlots');}">Max
+            <i data-bind="css: sortArrow('maxSpellSlots')"></i></th>
+          <th class="col-sm-1 hidden-sm hidden-xs" data-bind="click: function(){sortBy('resetsOn');}">Resets on
+            <i data-bind="css: sortArrow('resetsOn')"></i></th>
+          <th class="col-sm-4 text-center" data-bind="click: function(){sortBy('usedSpellSlots');}">Used
+            <i data-bind="css: sortArrow('usedSpellSlots')"></i></th>
+          <th class="col-xs-1">Reset</th>
+          <th class="col-sm-1"> <a data-toggle="modal" data-target="#addSpellSlot" href="#"><i class="fa fa-plus fa-color"></i></a></th>
+        </tr>
+      </thead>
+      <tbody>
+      <!-- ko foreach: filteredAndSortedSlots -->
+        <tr class="row clickable">
+          <td class="col-sm-1 col-content-vertical" data-bind="click: $parent.editSlot"
+          href="#"
           data-toggle="modal"
           data-target="#viewSlot">
-					  <span data-bind="css: color" class="form-control color-picker-item" >
-					  </span>
-    			</td>
-					<td class="col-sm-1 col-content-vertical"
-					data-bind="click: $parent.editSlot, text: level"
-					href="#"
+            <span data-bind="css: color" class="form-control color-picker-item" >
+            </span>
+          </td>
+          <td class="col-sm-1 col-content-vertical"
+          data-bind="click: $parent.editSlot, text: level"
+          href="#"
           data-toggle="modal"
           data-target="#viewSlot"></td>
           <td class="col-sm-1 col-content-vertical"
@@ -35,16 +41,29 @@
             href="#"
             data-toggle="modal"
             data-target="#viewSlot"></td>
-					<td class="col-sm-4">
+          <td class="col-content-vertical col-sm-1 hidden-sm hidden-xs" data-bind="click: $parent.editSlot"
+          href="#"
+          data-toggle="modal"
+          data-target="#viewSlot">
+            <!-- ko if: $parent.needsResetsOnImg($data) -->
+            <img class="action-bar-icon" data-bind="attr: { 'src': $parent.resetsOnImgSource($data) }"></img>
+            <!-- /ko -->
+          </td>
+          <td class="col-sm-4">
             <plus-minus params="value: usedSpellSlots,
               max: maxSpellSlots"></plus-minus>
-					</td>
-					<td class="col-content-vertical">
-						<a data-bind="click: $parent.removeSlot" href="#">
-							<i class="fa fa-trash-o fa-color-hover"> </i>
-						</a>
-					</td>
-				</tr>
+          </td>
+          <td class="col-content-vertical col-xs-1 text-center"> <!--Refresh -->
+            <a data-bind="click: $parent.resetSlots" href="#">
+              <i class="fa fa-refresh fa-color"> </i>
+            </a>
+          </td>
+          <td class="col-content-vertical">
+            <a data-bind="click: $parent.removeSlot" href="#">
+              <i class="fa fa-trash-o fa-color-hover"> </i>
+            </a>
+          </td>
+        </tr>
       <!-- /ko -->
       <!-- ko if: filteredAndSortedSlots().length == 0 -->
         <tr class="clickable">
@@ -56,39 +75,39 @@
         </tr>
       <!-- /ko -->
       </tbody>
-		</table>
-	</div>
+    </table>
+  </div>
 </div>
 
 <!-- Add Modal -->
 <div class="modal fade" id="addSpellSlot" tabindex="-1" role="dialog"
-	aria-labelledby="addSpellSlotLabel" data-bind="modal: {
-		onopen: modalFinishedAnimating}">
-	<div class="modal-dialog" role="document">
-		<div class="modal-content">
-			<div class="modal-header">
-				<button type="button" class="close" data-dismiss="modal" aria-label="Close">
-					<span aria-hidden="true">&times;</span> </button>
-				<h4 class="modal-title" id="addSkillLabel">
-					Add a spell slot.
-				</h4>
-			</div>
-			<div class="modal-body">
-				<form class="form-horizontal">
-					<div class="form-group">
-						<label for="name" class="col-sm-2 control-label">Level</label>
-						<div class="col-sm-10">
-							<input type="number" class="form-control" id="level" min="1" max="9"
-								data-bind='textInput: blankSlot().level'>
-						</div>
-					</div>
-					<div class="form-group">
-						<label for="bonus" class="col-sm-2 control-label">Max</label>
-						<div class="col-sm-10">
-							<input type="number" class="form-control" id="max" min="1" max="4"
+  aria-labelledby="addSpellSlotLabel" data-bind="modal: {
+    onopen: modalFinishedAnimating}">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span> </button>
+        <h4 class="modal-title" id="addSkillLabel">
+          Add a spell slot.
+        </h4>
+      </div>
+      <div class="modal-body">
+        <form class="form-horizontal">
+          <div class="form-group">
+            <label for="name" class="col-sm-2 control-label">Level</label>
+            <div class="col-sm-10">
+              <input type="number" class="form-control" id="level" min="1" max="9"
+                data-bind='textInput: blankSlot().level'>
+            </div>
+          </div>
+          <div class="form-group">
+            <label for="bonus" class="col-sm-2 control-label">Max</label>
+            <div class="col-sm-10">
+              <input type="number" class="form-control" id="max" min="1" max="4"
                 data-bind='textInput: blankSlot().maxSpellSlots, hasFocus: modifierHasFocus'>
-						</div>
-					</div>
+            </div>
+          </div>
           <div class="form-group">
             <label class="col-sm-2 control-label">Resets on...</label>
             <div class="col-sm-10">
@@ -107,51 +126,51 @@
                    name="blankresetsOnLong" value="long"
                    data-bind="checked: blankSlot().resetsOn"/>
                    <img class="action-bar-icon" src="/images/camping-tent.svg"></img>
-								    &nbsp;&nbsp;&nbsp;Long Rest
+                    &nbsp;&nbsp;&nbsp;Long Rest
                 </label>
               </div>
             </div>
           </div>
-					<div class="modal-footer">
-						<button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button> <button type="button" class="btn btn-primary" data-bind='click: addSlot' data-dismiss="modal">Add</button>
-					</div>
-				</form>
-			</div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button> <button type="button" class="btn btn-primary" data-bind='click: addSlot' data-dismiss="modal">Add</button>
+          </div>
+        </form>
+      </div>
 
 <!-- Modal Body -->
-		</div>
+    </div>
 <!-- Modal Content -->
-	</div>
+  </div>
 <!-- Modal Dialog -->
 </div>
 <!-- Modal Fade -->
 <!-- ViewEdit Modal -->
-	<div class="modal fade" id="viewSlot" tabindex="-1" role="dialog"
-		aria-labelledby="viewSlotLabel" data-bind="modal: {
-			 onopen: editModalOpen}, with: selecteditem">
-		<div class="modal-dialog" role="document">
-			<div class="modal-content">
-				<div class="modal-header">
-					<button type="button" class="close" data-dismiss="modal" aria-label="Close"> <span aria-hidden="true">&times;</span> </button>
-					<h4 class="modal-title" id="addSlotLabel"> Edit your Spell Slot.
-					</h4>
-				</div>
-				<div class="modal-body">
-					<form class="form-horizontal">
-						<div class="form-group">
-							<label for="name" class="col-sm-2 control-label">Level</label>
-							<div class="col-sm-10">
-								<input type="number" class="form-control" id="name" min="1" max="9"
-									data-bind="value: level">
-							</div>
-						</div>
-						<div class="form-group">
-							<label for="bonus" class="col-sm-2 control-label">Max</label>
-							<div class="col-sm-10">
-								<input type="number" class="form-control" id="bonus" min="1" max="4"
+  <div class="modal fade" id="viewSlot" tabindex="-1" role="dialog"
+    aria-labelledby="viewSlotLabel" data-bind="modal: {
+       onopen: editModalOpen}, with: selecteditem">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close"> <span aria-hidden="true">&times;</span> </button>
+          <h4 class="modal-title" id="addSlotLabel"> Edit your Spell Slot.
+          </h4>
+        </div>
+        <div class="modal-body">
+          <form class="form-horizontal">
+            <div class="form-group">
+              <label for="name" class="col-sm-2 control-label">Level</label>
+              <div class="col-sm-10">
+                <input type="number" class="form-control" id="name" min="1" max="9"
+                  data-bind="value: level">
+              </div>
+            </div>
+            <div class="form-group">
+              <label for="bonus" class="col-sm-2 control-label">Max</label>
+              <div class="col-sm-10">
+                <input type="number" class="form-control" id="bonus" min="1" max="4"
                   data-bind="value: maxSpellSlots, hasFocus: $parent.editHasFocus">
-							</div>
-						</div>
+              </div>
+            </div>
            <div class="form-group">
            <label class="col-sm-2 control-label">Resets on...</label>
              <div class="col-sm-10">
@@ -173,17 +192,17 @@
                </div>
              </div>
            </div>
-					</div>
-					<div class="modal-footer">
-						<button type="button" class="btn btn-primary" data-dismiss="modal">Done</button>
-					</div>
-				</form>
-			</div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-primary" data-dismiss="modal">Done</button>
+          </div>
+        </form>
+      </div>
 
 <!-- Modal Body -->
-		</div>
+    </div>
 <!-- Modal Content -->
-	</div>
+  </div>
 <!-- Modal Dialog -->
 </div>
 <!-- End with statement -->

--- a/charactersheet/charactersheet/viewmodels/character/spell_slots.js
+++ b/charactersheet/charactersheet/viewmodels/character/spell_slots.js
@@ -158,6 +158,10 @@ function SpellSlotsViewModel() {
         self.blankSlot().level(self.slots().length + 1);
     };
 
+    self.resetSlot = function(slot) {
+        slot.usedSpellSlots(0);
+    };
+
     self.resetSlots = function() {
         self.slots().forEach(function(slot, i, _) {
             slot.usedSpellSlots(0);

--- a/charactersheet/charactersheet/viewmodels/character/spell_slots.js
+++ b/charactersheet/charactersheet/viewmodels/character/spell_slots.js
@@ -9,7 +9,9 @@ function SpellSlotsViewModel() {
         'maxSpellSlots asc': { field: 'maxSpellSlots', direction: 'asc', numeric: true},
         'maxSpellSlots desc': { field: 'maxSpellSlots', direction: 'desc', numeric: true},
         'usedSpellSlots asc': { field: 'usedSpellSlots', direction: 'asc', numeric: true},
-        'usedSpellSlots desc': { field: 'usedSpellSlots', direction: 'desc', numeric: true}
+        'usedSpellSlots desc': { field: 'usedSpellSlots', direction: 'desc', numeric: true},
+        'resetsOn asc': { field: 'resetsOn', direction: 'asc'},
+        'resetsOn desc': { field: 'resetsOn', direction: 'desc'}
     };
 
     self.slots = ko.observableArray([]);
@@ -46,6 +48,20 @@ function SpellSlotsViewModel() {
     };
 
     /* UI Methods */
+
+    self.needsResetsOnImg = function(slot){
+        return slot.resetsOn() != '';
+    };
+
+    self.resetsOnImgSource = function(slot){
+        if(slot.resetsOn() === 'long') {
+            return '/images/camping-tent-blue.svg';
+        } else if (slot.resetsOn() === 'short') {
+            return '/images/meditation-blue.svg';
+        } else {
+            throw 'Unexpected feature resets on string.';
+        }
+    };
 
     /**
      * Filters and sorts the slots for presentation in a table.

--- a/test/characters/jebeddo_data.js
+++ b/test/characters/jebeddo_data.js
@@ -331,25 +331,29 @@ var jebeddo_data = {
       "characterId": "3ad59319-3f74-42e0-ab2a-67f3e0fc62b5",
       "level": "1",
       "maxSpellSlots": "4",
-      "usedSpellSlots": 0
+      "usedSpellSlots": 0,
+      "resetsOn": ""
     },
     {
       "characterId": "3ad59319-3f74-42e0-ab2a-67f3e0fc62b5",
       "level": 2,
       "maxSpellSlots": "3",
-      "usedSpellSlots": 0
+      "usedSpellSlots": 0,
+      "resetsOn": ""
     },
     {
       "characterId": "3ad59319-3f74-42e0-ab2a-67f3e0fc62b5",
       "level": 3,
       "maxSpellSlots": "3",
-      "usedSpellSlots": 0
+      "usedSpellSlots": 0,
+      "resetsOn": ""
     },
     {
       "characterId": "3ad59319-3f74-42e0-ab2a-67f3e0fc62b5",
       "level": 4,
       "maxSpellSlots": 1,
-      "usedSpellSlots": 0
+      "usedSpellSlots": 0,
+      "resetsOn": ""
     }
   ],
   "Item": [

--- a/test/viewmodels/test_spell_slots.js
+++ b/test/viewmodels/test_spell_slots.js
@@ -118,6 +118,22 @@ describe('Spell Slots View Model', function() {
         });
     });
 
+    describe('Reset Slot', function() {
+        it('should reset slot count to 0.', function() {
+            simple.mock(CharacterManager, 'activeCharacter').callFn(MockCharacterManager.activeCharacter);
+            var p = new SpellSlotsViewModel();
+            p.blankSlot().maxSpellSlots(3);
+            p.addSlot();
+            p.blankSlot().maxSpellSlots(3);
+            p.addSlot();
+            p.slots()[0].usedSpellSlots(1);
+            p.slots()[1].usedSpellSlots(1);
+            p.resetSlot(p.slots()[0]);
+            p.slots()[0].usedSpellSlots().should.equal(0);
+            p.slots()[1].usedSpellSlots().should.equal(1);
+        });
+    });
+
     describe('Clear', function() {
         it('should clear all the values in spell slots.', function() {
             var p = new SpellSlotsViewModel();


### PR DESCRIPTION
### Summary of Changes

Fix UI on Spell Slots to match Tracked Features

Includes:

* Add short/long rest icons
* Add sorting back
* Changed reset col to match tracked features

### Issues Fixed

Fixes #1162 

### Screen Shot of Proposed Changes (if UI related)

<img width="898" alt="screen shot 2017-01-29 at 7 50 33 pm" src="https://cloud.githubusercontent.com/assets/5814150/22411855/31dda8ee-e65d-11e6-8120-03e8d7ff9dc3.png">


<img width="260" alt="screen shot 2017-01-29 at 7 47 44 pm" src="https://cloud.githubusercontent.com/assets/5814150/22412336/428a6d08-e662-11e6-9355-b7c8354c5c25.png">
