### PR TITLE
Removes protocol method which could cause content from Gravatar to be blocked over HTTPS

### DIFF
--- a/charactersheet/charactersheet/models/common/player_info.js
+++ b/charactersheet/charactersheet/models/common/player_info.js
@@ -4,7 +4,7 @@ function PlayerInfo() {
     var self = this;
     self.ps = PersistenceService.register(PlayerInfo, self);
     
-    self.GRAVATAR_BASE_URL = 'http://www.gravatar.com/avatar/{}?d=mm';
+    self.GRAVATAR_BASE_URL = '//www.gravatar.com/avatar/{}?d=mm';
        
     self.characterId = ko.observable(null);
     self.email = ko.observable('');

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -54,7 +54,7 @@ var ImageFixture = {
 var PlayerInfoFixture = {
     email: 'brian@brianschrader.com',
     characterId: '12345',
-    gravatarUrl: 'http://www.gravatar.com/avatar/11b074a636e00292c98e3e60f7e16595?d=mm'
+    gravatarUrl: '//www.gravatar.com/avatar/11b074a636e00292c98e3e60f7e16595?d=mm'
 };
 
 var WeaponFixture = {


### PR DESCRIPTION
### Summary of Changes

Insecure resources can be blocked by browsers in secure settings. Removing the protocol means the browser will use whatever protocol it was served with.

![](https://dl.dropboxusercontent.com/s/8z1uiwau8pvdt75/Screenshot%202017-02-27%2017.08.29.png?dl=0)

### Issues Fixed

None logged

### Changes Proposed (if any)

None

### Screen Shot of Proposed Changes (if UI related)

None
