### PR TITLE
"Join a party" tab is now displayed by default.

### DIFF
--- a/charactersheet/charactersheet/viewmodels/common/party_manager.js
+++ b/charactersheet/charactersheet/viewmodels/common/party_manager.js
@@ -23,6 +23,11 @@ function PartyManagerViewModel() {
         Notifications.xmpp.connected.add(self.dataHasChanged);
         self.parties(self._getParties());
 
+        if (self.parties().length > 0) {
+            // Show party tab first.
+            self.createOrJoin('join');
+        }
+
         Notifications.party.joined.add(self._handleSubscription);
         Notifications.party.left.add(self._handleUnsubscription);
 


### PR DESCRIPTION
### Summary of Changes

"Join a party" tab is now displayed by default if the user has an saved parties

### Issues Fixed

Fixes #1339 

### Changes Proposed (if any)

None

### Screen Shot of Proposed Changes (if UI related)

None
