### PR TITLE
Party modal text fix

### DIFF
--- a/charactersheet/charactersheet/models/common/character.js
+++ b/charactersheet/charactersheet/models/common/character.js
@@ -98,8 +98,7 @@ function Character() {
         //Notify all apps to save their data.
         Notifications.global.save.dispatch();
         //Write the file.
-        var string = encodeURIComponent(JSON.stringify(Character.exportCharacter(self.key())),
-            null, 2); //Pretty print
+        var string = encodeURIComponent(JSON.stringify(Character.exportCharacter(self.key())));
         var filename = self.playerTitle();
         var blob = new Blob([string], {type: 'application/json'});
         saveAs(blob, filename);

--- a/charactersheet/charactersheet/models/common/chat_room.js
+++ b/charactersheet/charactersheet/models/common/chat_room.js
@@ -18,7 +18,7 @@ function ChatRoom() {
     self.partyId = ko.observable();
 
     self.chatName = ko.pureComputed(function() {
-        return self.chatId().split('@')[0];
+        return Strophe.getNodeFromJid(self.chatId());
     });
 
     self.clear = function() {

--- a/charactersheet/charactersheet/models/common/chat_room.js
+++ b/charactersheet/charactersheet/models/common/chat_room.js
@@ -17,6 +17,10 @@ function ChatRoom() {
     self.isParty = ko.observable(false);
     self.partyId = ko.observable();
 
+    self.chatName = ko.pureComputed(function() {
+        return self.chatId().split('@')[0];
+    });
+
     self.clear = function() {
         var values = new ChatRoom().exportValues();
         var mapping = ko.mapping.autoignore(self, self.mapping);

--- a/charactersheet/charactersheet/templates/common/party_manager.tmpl.html
+++ b/charactersheet/charactersheet/templates/common/party_manager.tmpl.html
@@ -60,7 +60,7 @@
                     <button type="button" class="list-group-item text-left col-xs-12"
                       data-bind="click: $parent.joinPartyWasClickedWithParty">
                       <div class="col-xs-11">
-                        <span data-bind="text: chatId"></span><br/>
+                        <span data-bind="text: chatName"></span><br/>
                         <small class="text-muted">Created:
                           <span data-bind="text: $parent.dateCreatedLabel($data)"></span>
                         </small>

--- a/charactersheet/charactersheet/viewmodels/common/chat/chat_detail.js
+++ b/charactersheet/charactersheet/viewmodels/common/chat/chat_detail.js
@@ -237,6 +237,6 @@ var ChatDetailViewModelMemberTemplate = '\
     <div class="col-md-2 col-xs-3 text-center col-padded">\
         <img src="{card.image}" width="60" height="60" \
             class="img img-circle img-padded" /><br />\
-        <small class="text-muted">{card.name}</small>\
+        <small class="text-lightgray">{card.name}</small>\
     </div>\
 ';

--- a/charactersheet/style/site.css
+++ b/charactersheet/style/site.css
@@ -278,6 +278,10 @@ div.hr {
   color: #2c3e50;
 }
 
+.text-lightgray {
+  color: #798d8f;
+}
+
 .tab-subtext:hover {
   color: #2c3e50;
 }


### PR DESCRIPTION
### Summary of Changes

Room names are just the name now without the full jid.
Makes players names in chat window less subdued.

### Issues Fixed



### Screen Shot of Proposed Changes (if UI related)

![image](https://cloud.githubusercontent.com/assets/7286387/26516658/04e50dc6-423f-11e7-8c91-ab564bd32536.png)

