### PR TITLE
Link detection

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -40,7 +40,8 @@
     "toastr": "2.1.3",
     "Strophe.js": "strophe#^1.1.3",
     "lz-string": "1.4.4",
-    "clipboard": "~1.6.1"
+    "clipboard": "~1.6.1",
+    "linkifyjs": "^2.1.4"
   },
   "resolutions": {
     "webcomponentsjs": "~0.5.4"

--- a/charactersheet/charactersheet/index.html
+++ b/charactersheet/charactersheet/index.html
@@ -370,6 +370,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <script src="/bower_components/lz-string/libs/lz-string.min.js"></script>
 <script src="/bower_components/uri.js/src/URI.min.js"></script>
 <script src="/bower_components/uri.js/src/URI.fragmentQuery.js"></script>
+<script src="/bower_components/linkifyjs/linkify.js"></script>
+<script src="/bower_components/linkifyjs/linkify-string.js"></script>
 <!-- Bindings -->
 <script src="/bin/date-format.js"></script>
 <script src="/bin/markdown.min.js"></script>

--- a/charactersheet/charactersheet/settings.js
+++ b/charactersheet/charactersheet/settings.js
@@ -90,7 +90,7 @@ var Settings = {
     linkifyOptions : {
         format: {
             url: function (value) {
-            return value.length > 50 ? value.slice(0, 50) + '…' : value
+                return value.length > 50 ? value.slice(0, 50) + '…' : value;
             }
         }
     },

--- a/charactersheet/charactersheet/settings.js
+++ b/charactersheet/charactersheet/settings.js
@@ -83,6 +83,19 @@ var Settings = {
     },
 
     /**
+     * Override for default linkify options.
+     * Documentation: http://soapbox.github.io/linkifyjs/docs/
+     * More options: http://soapbox.github.io/linkifyjs/docs/options.html
+     */
+    linkifyOptions : {
+        format: {
+            url: function (value) {
+            return value.length > 50 ? value.slice(0, 50) + '…' : value
+            }
+        }
+    },
+
+    /**
      * A set of Data Repository URLs and Keys. Each item in this list should
      * contain both a URL and a Key.
      *

--- a/charactersheet/charactersheet/viewmodels/common/chat/chat_log_chat_item.js
+++ b/charactersheet/charactersheet/viewmodels/common/chat/chat_log_chat_item.js
@@ -39,7 +39,7 @@ function ChatLogChatItem(message) {
     });
 
     self.html = ko.pureComputed(function() {
-        return self.message.html();
+        return linkifyStr(self.message.html(), Settings.linkifyOptions);
     });
 
     self.saveToNotes = function() {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "cryptojs": "^2.5.3",
+    "linkifyjs": "^2.1.4",
     "socket.io": "^1.3.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   },
   "dependencies": {
     "cryptojs": "^2.5.3",
-    "linkifyjs": "^2.1.4",
     "socket.io": "^1.3.7"
   }
 }


### PR DESCRIPTION
### Summary of Changes

- Adds [linkify](http://soapbox.github.io/linkifyjs/docs/) for parsing links, emails, and hashtags to html markup
- Links are truncated at 50 characters to prevent long links from displaying
- Only implemented in chat

### Issues Fixed

Fixes #1423 

### Screen Shot of Proposed Changes (if UI related)

![image](https://user-images.githubusercontent.com/7286387/27255891-9a2eeb62-535c-11e7-809b-584cb47437b0.png)

