### PR TITLE
Dropbox image converter

### DIFF
--- a/charactersheet/charactersheet/models/common/character.js
+++ b/charactersheet/charactersheet/models/common/character.js
@@ -86,7 +86,7 @@ function Character() {
 
         if (image.imageSource() === 'link') {
             var imageModel = PersistenceService.findFirstBy(ImageModel, 'characterId', self.key());
-            return imageModel && imageModel.imageUrl() ? imageModel.imageUrl() : defaultImage;
+            return imageModel && imageModel.imageUrl() ? Utility.string.createDirectDropboxLink(imageModel.imageUrl()) : defaultImage;
         } else if (image.imageSource() === 'email') {
             var info = PersistenceService.findFirstBy(PlayerInfo, 'characterId', self.key());
             return info && info.gravatarUrl() ? info.gravatarUrl() : defaultImage;

--- a/charactersheet/charactersheet/templates/dm/encounter_sections/environment_section.tmpl.html
+++ b/charactersheet/charactersheet/templates/dm/encounter_sections/environment_section.tmpl.html
@@ -30,7 +30,7 @@
           <hr data-bind="visible: shouldShowDividingMarker"/>
           <div>
             <!-- ko if: imageUrl -->
-            <img data-bind="attr: { src: imageUrl, width: imageWidth }, css: imageClass"
+            <img data-bind="attr: { src: convertedImageLink, width: imageWidth }, css: imageClass"
               class="img-responsive img-rounded">
             <!-- /ko -->
             <span data-bind="markdownPreview: description"

--- a/charactersheet/charactersheet/utilities/convenience.js
+++ b/charactersheet/charactersheet/utilities/convenience.js
@@ -56,7 +56,7 @@ Utility.string.truncateStringAtLength = function(value, truncateAt) {
  */
 Utility.string.createDirectDropboxLink = function(link) {
     return link ? link.replace('www.dropbox.com', 'dl.dropboxusercontent.com') : '';
-}
+};
 
 /**
  * Updates a single element in an observable array.

--- a/charactersheet/charactersheet/utilities/convenience.js
+++ b/charactersheet/charactersheet/utilities/convenience.js
@@ -48,6 +48,17 @@ Utility.string.truncateStringAtLength = function(value, truncateAt) {
 };
 
 /**
+ * Converts a shareable dropbox link to a direct image link.
+ * `www.dropbox.com` will be converted to `dl.dropboxusercontent.com`
+ * @param link: link to be converted
+ *
+ * @return direct link to dropbox image
+ */
+Utility.string.createDirectDropboxLink = function(link) {
+    return link ? link.replace('www.dropbox.com', 'dl.dropboxusercontent.com') : '';
+}
+
+/**
  * Updates a single element in an observable array.
  *
  * @param array: observable array that contains the item to be updated.

--- a/charactersheet/charactersheet/viewmodels/common/player_image.js
+++ b/charactersheet/charactersheet/viewmodels/common/player_image.js
@@ -98,7 +98,7 @@ function PlayerImageViewModel() {
 
     self.playerImageSrc = ko.pureComputed(function() {
         if (self.imageSource() == 'link') {
-            return self.imageUrl();
+            return Utility.string.createDirectDropboxLink(self.imageUrl());
         }
 
         var url = self._getEmailUrl();

--- a/charactersheet/charactersheet/viewmodels/dm/encounter_sections/environment_section.js
+++ b/charactersheet/charactersheet/viewmodels/dm/encounter_sections/environment_section.js
@@ -23,7 +23,7 @@ function EnvironmentSectionViewModel(parentEncounter) {
     self.load = function() {
         Notifications.global.save.add(self.save);
         Notifications.encounters.changed.add(self._dataHasChanged);
-        
+
         var key = CharacterManager.activeCharacter().key();
         var environmentSection = PersistenceService.findFirstBy(EnvironmentSection, 'encounterId', self.encounterId());
         if (environmentSection) {
@@ -48,7 +48,7 @@ function EnvironmentSectionViewModel(parentEncounter) {
 
     self.unload = function() {
         Notifications.global.save.remove(self.save);
-        Notifications.encounters.changed.remove(self._dataHasChanged);        
+        Notifications.encounters.changed.remove(self._dataHasChanged);
     };
 
     self.save = function() {
@@ -109,6 +109,10 @@ function EnvironmentSectionViewModel(parentEncounter) {
             return 'embedded-image pull-right';
         }
         return 'embedded-image';
+    });
+
+    self.convertedImageLink = ko.pureComputed(function() {
+        return Utility.string.createDirectDropboxLink(self.imageUrl());
     });
 
     /* Private Methods */


### PR DESCRIPTION
### Summary of Changes

Added convenience method for converting dropbox links to direct images. Applied to character picker, environment section, and profile picture.

__Note__: The reason I run the link converter even before knowing if it's a dropbox link is because I simply do a `.replace()`, and if it doesn't have the criteria, it just returns the same input string, which shouldn't mess anything up.

### Issues Fixed

Fixes #1407 
Fixes #1429 
