### PR TITLE
Adds placeholder for dashboard if no one is connected.

### DIFF
--- a/charactersheet/charactersheet/templates/dm/party.tmpl.html
+++ b/charactersheet/charactersheet/templates/dm/party.tmpl.html
@@ -1,5 +1,11 @@
 <!-- ko with: partyViewModel -->
 <div class="row">
+  <!-- ko if: players().length == 0-->
+  <div class="detail-place-holder well text-center">
+    <p class="lead text-muted heading">There's no one here.</p>
+    <p class="text-muted">Once your players join the party, they'll show up here.</p>
+  </div>
+  <!-- /ko -->
   <!-- ko foreach: players -->
   <div class="col-sm-4">
     <div class="panel panel-default">


### PR DESCRIPTION
### Summary of Changes

When no one is in the party but the DM, they now get a message explaining why the Dashboard is blank.

### Issues Fixed

None logged

### Changes Proposed (if any)

None

### Screen Shot of Proposed Changes (if UI related)

![](https://dl.dropboxusercontent.com/s/6p77ilz48e66dcc/Screenshot%202017-07-01%2016.10.08.png?dl=0)