### PR TITLE
Remake of encounter-layout after botched branch creation

### DIFF
--- a/charactersheet/charactersheet/components/nested-list.js
+++ b/charactersheet/charactersheet/components/nested-list.js
@@ -82,7 +82,7 @@ function NestedListComponentViewModel(params) {
 ko.components.register('nested-list', {
     viewModel: NestedListComponentViewModel,
     template: '\
-        <div data-bind="foreach: cells" class="list-group no-bottom-margin">\
+        <div data-bind="foreach: cells" class="list-group no-bottom-margin master-list">\
             <a href="#" class="list-group-item" \
                 data-bind="css: $parent.isActiveCSS($data), \
                     click: $parent.selectCell">\

--- a/charactersheet/charactersheet/templates/dm/encounter.tmpl.html
+++ b/charactersheet/charactersheet/templates/dm/encounter.tmpl.html
@@ -5,9 +5,9 @@
       <small>Create and manage events and sections of your campaign. Group encounters under a common topic, or...</small>
     </div>
     <div class="row">
-      <div class="col-xs-12 col-sm-4">
+      <div class="col-xs-12 col-sm-4 col-md-3 tight-right">
         <div class="panel panel-default">
-          <div class="panel-body">
+          <div class="panel-body tight-inner">
             <div class="panel-heading">
               <div class="h4">
                 Encounters
@@ -24,7 +24,7 @@
           </div>
         </div>
       </div>
-      <div class="col-xs-12 col-sm-8">
+      <div class="col-xs-12 col-sm-8 col-md-9">
         <!-- ko if: encounterDetailViewModel -->
         <div data-bind="template: {
           name: 'encounter_detail.tmpl',

--- a/charactersheet/style/site.css
+++ b/charactersheet/style/site.css
@@ -818,3 +818,17 @@ li.image-chat-highlight {
 .exhibitActiveIcon {
   color: #0EADE1;
 }
+
+.tight-right {
+  padding-right:0px;
+}
+
+.tight-inner {
+  padding-left:0px;
+  padding-right: 0px;
+}
+
+.master-list .list-group-item {
+  border-radius: 0px;
+  border: none;
+}


### PR DESCRIPTION
REMAKE AFTER CORRUPTED BRANCH

### Summary of Changes

- Makes encounters detail bigger on larger devices
- Removes some spacing between master and detail views.
- Removes list outlines.
- Removes inner padding on master list. Items now fill the panel.

### Issues Fixed

None logged

### Changes Proposed (if any)

None

### Screen Shot of Proposed Changes (if UI related)

### Before

![](https://dl.dropboxusercontent.com/s/e26a0yvx8r7g9x6/Screenshot%202017-07-07%2014.28.10.png?dl=0)


### After

![](https://dl.dropboxusercontent.com/s/jqsehlq6lk4sms0/Screenshot%202017-07-07%2014.47.50.png?dl=0)
