### PR TITLE
Fixes issue with switching characters 

### DIFF
--- a/charactersheet/charactersheet/services/common/sync/card_service.js
+++ b/charactersheet/charactersheet/services/common/sync/card_service.js
@@ -35,6 +35,15 @@ function _pCardService(configuration) {
         self._setupNotifications();
     };
 
+    self.deinit = function() {
+        Notifications.xmpp.routes.pcard.remove(self.handlePCard);
+        Notifications.chat.member.left.remove(self.removePlayer);
+        Notifications.party.left.remove(self.clearPCards);
+
+        self._teardownNotifications();
+
+    };
+
     self.dataHasChanged = function() {
         var card = self._buildCard();
         self.publishCard(card);
@@ -74,6 +83,14 @@ function _pCardService(configuration) {
 
         self.configuration.fields.forEach(function(field, idx, _) {
             field.refreshOn.add(self.dataHasChanged);
+        });
+    };
+
+    self._teardownNotifications = function() {
+        Notifications.party.joined.remove(self._updateCurrentNode);
+
+        self.configuration.fields.forEach(function(field, idx, _) {
+            field.refreshOn.remove(self.dataHasChanged);
         });
     };
 

--- a/charactersheet/charactersheet/viewmodels/character/character_root.js
+++ b/charactersheet/charactersheet/viewmodels/character/character_root.js
@@ -225,6 +225,8 @@ function CharacterRootViewModel() {
 
         Notifications.party.joined.remove(self._updateCurrentNode);
         Notifications.party.joined.remove(self._removeCurrentNode);
+
+        self.characterCardPublishingService.deinit();
     };
 
     //Private Methods

--- a/charactersheet/charactersheet/viewmodels/common/party_manager.js
+++ b/charactersheet/charactersheet/viewmodels/common/party_manager.js
@@ -122,7 +122,8 @@ function PartyManagerViewModel() {
 
     self.dataHasChanged = function() {
         var token = PersistenceService.findAll(AuthenticationToken)[0];
-        self.loggedIn(token && token.isValid());
+        var xmpp = XMPPService.sharedService();
+        self.loggedIn(token && token.isValid() && xmpp.connection.authenticated);
     };
 
     /* Private Methods */

--- a/charactersheet/charactersheet/viewmodels/dm/dm_root.js
+++ b/charactersheet/charactersheet/viewmodels/dm/dm_root.js
@@ -162,6 +162,8 @@ function DMRootViewModel() {
 
         Notifications.xmpp.pubsub.subscribed.remove(self._updateCurrentNode);
         Notifications.xmpp.pubsub.unsubscribed.remove(self._removeCurrentNode);
+
+        self.dmCardService.deinit();
     };
 
     //Private Methods


### PR DESCRIPTION
### Summary of Changes

- The Character/DM card publishing services no longer keep their notifications active after switching characters.
- The party manager no longer re-shows the "Manage Party" link after switching characters unless the user is actually logged in.

### Issues Fixed

None logged