### PR TITLE
Fixes issue where notes do not save when switching notes.

### DIFF
--- a/charactersheet/charactersheet/viewmodels/common/chat/chat_log_read_aloud_item.js
+++ b/charactersheet/charactersheet/viewmodels/common/chat/chat_log_read_aloud_item.js
@@ -60,6 +60,7 @@ function ChatLogReadAloudItem(message) {
         Notifications.notes.changed.dispatch();
         Notifications.userNotification.successNotification.dispatch('Saved to Notes.');
     };
+
     /* Card Methods */
 
     self.getCard = function() {

--- a/charactersheet/charactersheet/viewmodels/common/notes.js
+++ b/charactersheet/charactersheet/viewmodels/common/notes.js
@@ -54,6 +54,7 @@ function NotesViewModel() {
 
     self.selectNote = function(note) {
         self.selectedNote(note);
+        self.selectedNote().text.subscribe(self.selectedNote().save);
     };
 
     self.isActiveCSS = function(note) {


### PR DESCRIPTION
### Summary of Changes

- Fixes issue where notes are not saved when chat messages are saved. This could cause data loss in some cases.

### Issues Fixed

- Fixes #1487

### Changes Proposed (if any)

None

### Screen Shot of Proposed Changes (if UI related)

None