### PR TITLE
Fixes issue where any pushed party card would cause the exhibit to clear for most of the party

### DIFF
--- a/charactersheet/charactersheet/viewmodels/character/exhibit.js
+++ b/charactersheet/charactersheet/viewmodels/character/exhibit.js
@@ -16,6 +16,11 @@ function ExhibitViewModel() {
 
     self.exhibitGivenImage = function(newPCard) {
         var image = pCard.fromEntries(newPCard).get('exhibitImage')[0];
+        var playerType = pCard.fromEntries(newPCard).get('playerType')[0];
+
+        // Ignore non-DM cards.
+        if (PlayerTypes.dmPlayerType.key != playerType) { return; }
+
         if (image) {
             self.name(image.name);
             self.url(Utility.string.createDirectDropboxLink(image.url));


### PR DESCRIPTION
### Summary of Changes

- Players pushing cards no longer affects the Player Exhibit Service.

### Issues Fixed

Should fix #1491 as well

### Changes Proposed (if any)

None

### Screen Shot of Proposed Changes (if UI related)

None