### PR TITLE
Adds 4 minute XMPP ping to keep connection alive.

### DIFF
--- a/charactersheet/charactersheet/services/common/account/xmpp_connection_service.js
+++ b/charactersheet/charactersheet/services/common/account/xmpp_connection_service.js
@@ -56,7 +56,7 @@ function _XMPPService(config) {
     self._pingHandle = null;
 
     self.MAX_RETRIES = 3;
-    self.PING_INTERVAL = 4000000;
+    self.PING_INTERVAL = 240000;
 
     /**
      * A lazily instantiated connection to the XMPP backend server.

--- a/charactersheet/charactersheet/services/common/account/xmpp_connection_service.js
+++ b/charactersheet/charactersheet/services/common/account/xmpp_connection_service.js
@@ -56,7 +56,7 @@ function _XMPPService(config) {
     self._pingHandle = null;
 
     self.MAX_RETRIES = 3;
-    self.PING_INTERVAL = 5000000;
+    self.PING_INTERVAL = 4000000;
 
     /**
      * A lazily instantiated connection to the XMPP backend server.


### PR DESCRIPTION
### Summary of Changes

Adds new polling for XMPP Connections 

**Update**

> WebSocket Connections time out at 5 mins if no traffic. The previous timeout
ran the risk of operating directly on that limit. A 1 minute buffer should fix
that.

### Issues Fixed

Fixes issue where XMPP Connections will timeout after long periods of idle.

### Changes Proposed (if any)

None

### Screen Shot of Proposed Changes (if UI related)

None