### PR TITLE
Adds a new XMPP Websocket Connection Retry Cycle that actually works.

### DIFF
--- a/charactersheet/charactersheet/models/common/message.js
+++ b/charactersheet/charactersheet/models/common/message.js
@@ -129,7 +129,7 @@ function Message() {
             to: self.to(),
             from: self.from(),
             id: self.id(),
-            type: self.type(),
+            type: self.type()
         }).c('body').up().c('html', {
             xmlns: Strophe.NS.HTML
         }).c('body', {} , self.html()).up();

--- a/charactersheet/charactersheet/models/common/message.js
+++ b/charactersheet/charactersheet/models/common/message.js
@@ -129,7 +129,7 @@ function Message() {
             to: self.to(),
             from: self.from(),
             id: self.id(),
-            type: 'chat'
+            type: self.type(),
         }).c('body').up().c('html', {
             xmlns: Strophe.NS.HTML
         }).c('body', {} , self.html()).up();

--- a/charactersheet/charactersheet/services/common/account/messaging/chat_service.js
+++ b/charactersheet/charactersheet/services/common/account/messaging/chat_service.js
@@ -37,8 +37,8 @@ function _ChatService(config) {
     self.init = function() {
         self._setupConnection();
 
+        Notifications.xmpp.initialized.add(self._setupConnection);
         Notifications.xmpp.connected.add(self._handleConnect);
-        Notifications.xmpp.connected.add(self._setupConnection);
         Notifications.xmpp.disconnected.add(self._teardownConnection);
         Notifications.characterManager.changing.add(self._leaveAll);
         Notifications.party.joined.add(self._setupRooms);
@@ -48,8 +48,8 @@ function _ChatService(config) {
     self.deinit = function() {
         self._teardownConnection();
 
+        Notifications.xmpp.initialized.remove(self._setupConnection);
         Notifications.xmpp.connected.remove(self._handleConnect);
-        Notifications.xmpp.connected.remove(self._setupConnection);
         Notifications.xmpp.disconnected.remove(self._teardownConnection);
         Notifications.characterManager.changing.remove(self._leaveAll);
         Notifications.party.joined.remove(self._setupRooms);
@@ -57,19 +57,6 @@ function _ChatService(config) {
     };
 
     /* Public Methods */
-
-    self.send = function(room, message) {
-        var xmpp = XMPPService.sharedService();
-        if (room.isGroupChat()) {
-            var id = xmpp.connection.getUniqueId();
-            // TODO: Refactor. This is just sending plaintext messages.
-            xmpp.connection.muc.groupchat(message.to(), null, message.message(), id);
-        } else {
-            xmpp.connection.send(message.tree());
-        }
-        // Actually send the messages.
-        xmpp.connection.flush();
-    };
 
     self.join = function(jid, nick, isParty) {
         var xmpp = XMPPService.sharedService();

--- a/charactersheet/charactersheet/services/common/account/messaging/node_service.js
+++ b/charactersheet/charactersheet/services/common/account/messaging/node_service.js
@@ -90,11 +90,12 @@ function _NodeService(config) {
     self._isListeningForXMPPEvents = false;
 
     self.init = function() {
-        Notifications.party.roster.changed.add(self._getCards);
-
-        // Re-add them upon reconnection.
-        Notifications.xmpp.connected.add(self._addXMPPHandlers);
         self._addXMPPHandlers();
+
+
+        Notifications.party.roster.changed.add(self._getCards);
+        Notifications.xmpp.initialized.add(self._addXMPPHandlers);
+        Notifications.xmpp.disconnected.add(self._handleXMPPDisconnect);
     };
 
     /**
@@ -130,9 +131,7 @@ function _NodeService(config) {
             xmpp.connection.addHandler(self._handlePresenceRequest, null, 'presence', 'subscribe');
             xmpp.connection.addHandler(self._handlePresence, null, 'presence');
             xmpp.connection.addHandler(self._handleSuccessfulPresenceSubscription, null, 'presence', 'subscribed');
-
-            // DEBUG
-            XMPPService.sharedService().connection.addHandler(function(a) {console.log(a); return true;})        }
+        }
         self._isListeningForXMPPEvents = true;
     };
 

--- a/charactersheet/charactersheet/services/common/account/xmpp_connection_service.js
+++ b/charactersheet/charactersheet/services/common/account/xmpp_connection_service.js
@@ -134,6 +134,10 @@ function _XMPPService(config) {
                 console.log('Connected.');
             }
 
+            // We've successfully reconnected.
+            if (self._isAttemptingRetry) {
+                Notifications.xmpp.reconnected.dispatch();
+            }
             self._isAttemptingRetry = false;
 
             // Send initial presence.

--- a/charactersheet/charactersheet/services/common/account/xmpp_connection_service.js
+++ b/charactersheet/charactersheet/services/common/account/xmpp_connection_service.js
@@ -179,7 +179,7 @@ function _XMPPService(config) {
      */
     self._attemptRetry = function(forceReconnect) {
         if (!forceReconnect && self.connection.connected) {
-            console.log('Already connected, retry not forced. Skipping...')
+            console.log('Already connected, retry not forced. Skipping...');
             return;
         }
 

--- a/charactersheet/charactersheet/services/common/account/xmpp_connection_service.js
+++ b/charactersheet/charactersheet/services/common/account/xmpp_connection_service.js
@@ -6,7 +6,7 @@
  * custom configurations.
  */
 var XMPPServiceDefaultConfig = {
-    url: 'ws://localhost:5050/websocket/',
+    url: 'wss://adventurerscodex.com:5280/websocket/',
 
     connection: {
         // Specify a custom callback here.

--- a/charactersheet/charactersheet/utilities/notifications.js
+++ b/charactersheet/charactersheet/utilities/notifications.js
@@ -338,6 +338,7 @@ var Notifications = {
          * @param shouldNotify {bool} whether the event deserves to notify the user.
          */
         disconnected: new signals.Signal(),
+        reconnected: new signals.Signal(),
         error: new signals.Signal(),
 
         routes: {

--- a/charactersheet/charactersheet/utilities/notifications.js
+++ b/charactersheet/charactersheet/utilities/notifications.js
@@ -324,12 +324,18 @@ var Notifications = {
 
     xmpp: {
         /**
+         * Dispatched when a new connection object has been created, but before
+         * it is connected to the service.
+         */
+        initialized: new signals.Signal(),
+        /**
          * Dispatched when the XMPP connection is successfully established,
          * the given user is authenticated, and the connection is now usable.
          */
         connected: new signals.Signal(),
         /**
          * Dispatched when the XMPP connection has been successfully terminated.
+         * @param shouldNotify {bool} whether the event deserves to notify the user.
          */
         disconnected: new signals.Signal(),
         error: new signals.Signal(),

--- a/charactersheet/charactersheet/viewmodels/character/character_root.js
+++ b/charactersheet/charactersheet/viewmodels/character/character_root.js
@@ -216,6 +216,7 @@ function CharacterRootViewModel() {
 
         Notifications.party.joined.add(self._updateCurrentNode);
         Notifications.party.left.add(self._removeCurrentNode);
+        Notifications.xmpp.disconnected.add(self._removeCurrentNode);
     };
 
     self.unload = function() {
@@ -225,6 +226,7 @@ function CharacterRootViewModel() {
 
         Notifications.party.joined.remove(self._updateCurrentNode);
         Notifications.party.joined.remove(self._removeCurrentNode);
+        Notifications.xmpp.disconnected.remove(self._removeCurrentNode);
 
         self.characterCardPublishingService.deinit();
     };
@@ -261,5 +263,4 @@ function CharacterRootViewModel() {
         self.currentPartyNode(null);
         self._updatePartyStatus();
     };
-
 }

--- a/charactersheet/charactersheet/viewmodels/common/chat/chat_detail.js
+++ b/charactersheet/charactersheet/viewmodels/common/chat/chat_detail.js
@@ -137,12 +137,12 @@ function ChatDetailViewModel(chatCell, parent) {
         var xmpp = XMPPService.sharedService();
         var key = CharacterManager.activeCharacter().key();
 
-        // TODO FIX
         var message = new Message();
         message.importValues({
             from: xmpp.connection.jid,
-            message: self.message(),
+            html: self.message(),
             to: self.id(),
+            type: 'groupchat',
             id: xmpp.connection.getUniqueId(),
             characterId: key
         });
@@ -152,14 +152,7 @@ function ChatDetailViewModel(chatCell, parent) {
 
     self._sendMessage = function(message, onsuccess, onerror) {
         var xmpp = XMPPService.sharedService();
-        if (self.isGroupChat()) {
-            var id = xmpp.connection.getUniqueId();
-            // TODO: Refactor to be consistant with private chat.
-            xmpp.connection.muc.groupchat(message.to(), null, message.message(), id);
-        } else {
-            xmpp.connection.send(message.tree());
-        }
-        // Actually send the messages.
+        xmpp.connection.send(message.tree());
         xmpp.connection.flush();
     };
 

--- a/charactersheet/charactersheet/viewmodels/common/party_manager.js
+++ b/charactersheet/charactersheet/viewmodels/common/party_manager.js
@@ -21,6 +21,7 @@ function PartyManagerViewModel() {
 
     self.load = function() {
         Notifications.xmpp.connected.add(self.dataHasChanged);
+        Notifications.xmpp.reconnected.add(self._handleReconnection);
         Notifications.xmpp.disconnected.add(self._handleDisconnection);
         Notifications.xmpp.error.add(self._handleConnectionError);
         self.parties(self._getParties());
@@ -33,6 +34,7 @@ function PartyManagerViewModel() {
 
     self.unload = function() {
         Notifications.xmpp.connected.remove(self.dataHasChanged);
+        Notifications.xmpp.reconnected.remove(self._handleReconnection);
         Notifications.xmpp.disconnected.remove(self._handleDisconnection);
         Notifications.xmpp.error.remove(self._handleConnectionError);
         Notifications.party.joined.remove(self._handleSubscription);
@@ -205,6 +207,17 @@ function PartyManagerViewModel() {
             '<a href="https://adventurerscodex.com/faq.html#connection">Click here for ' +
             'more info.</a>',
             'A connection error has occurred.',
+            {
+                timeOut: 0,
+                extendedTimeOut: 0
+            }
+        );
+    };
+
+    self._handleReconnection = function(code) {
+        Notifications.userNotification.successNotification.dispatch(
+            'You\'re back online.',
+            'Connection reestablished',
             {
                 timeOut: 0,
                 extendedTimeOut: 0

--- a/charactersheet/charactersheet/viewmodels/common/party_manager.js
+++ b/charactersheet/charactersheet/viewmodels/common/party_manager.js
@@ -144,20 +144,22 @@ function PartyManagerViewModel() {
         }
     };
 
-    self._handleDisconnection = function() {
+    self._handleDisconnection = function(shouldNotify) {
         self.dataHasChanged();
         self.loggedIn(false);
         self.roomId(null);
         self.inAParty(false);
 
-        Notifications.userNotification.warningNotification.dispatch(
-            'It looks like you\'ve been disconnected. Is your internet ok?',
-            '',
-            {
-                timeOut: 0,
-                extendedTimeOut: 0
-            }
-        );
+        if (shouldNotify) {
+            Notifications.userNotification.warningNotification.dispatch(
+                'It looks like you\'ve been disconnected. Is your internet ok?',
+                '',
+                {
+                    timeOut: 0,
+                    extendedTimeOut: 0
+                }
+            );
+        }
     };
 
     self._handleSubscription = function(node, success) {

--- a/charactersheet/charactersheet/viewmodels/common/party_manager.js
+++ b/charactersheet/charactersheet/viewmodels/common/party_manager.js
@@ -21,6 +21,7 @@ function PartyManagerViewModel() {
 
     self.load = function() {
         Notifications.xmpp.connected.add(self.dataHasChanged);
+        Notifications.xmpp.disconnected.add(self._handleDisconnection);
         Notifications.xmpp.error.add(self._handleConnectionError);
         self.parties(self._getParties());
 
@@ -32,6 +33,7 @@ function PartyManagerViewModel() {
 
     self.unload = function() {
         Notifications.xmpp.connected.remove(self.dataHasChanged);
+        Notifications.xmpp.disconnected.remove(self._handleDisconnection);
         Notifications.xmpp.error.remove(self._handleConnectionError);
         Notifications.party.joined.remove(self._handleSubscription);
         Notifications.party.left.remove(self._handleUnsubscription);
@@ -140,6 +142,22 @@ function PartyManagerViewModel() {
         if (self.inAParty()) {
             self._handleUnsubscription('', true);
         }
+    };
+
+    self._handleDisconnection = function() {
+        self.dataHasChanged();
+        self.loggedIn(false);
+        self.roomId(null);
+        self.inAParty(false);
+
+        Notifications.userNotification.warningNotification.dispatch(
+            'It looks like you\'ve been disconnected. Is your internet ok?',
+            '',
+            {
+                timeOut: 0,
+                extendedTimeOut: 0
+            }
+        );
     };
 
     self._handleSubscription = function(node, success) {

--- a/charactersheet/charactersheet/viewmodels/dm/dm_root.js
+++ b/charactersheet/charactersheet/viewmodels/dm/dm_root.js
@@ -154,6 +154,7 @@ function DMRootViewModel() {
 
         Notifications.party.joined.add(self._updateCurrentNode);
         Notifications.party.left.add(self._removeCurrentNode);
+        Notifications.xmpp.disconnected.add(self._removeCurrentNode);
     };
 
     self.unload = function() {
@@ -162,6 +163,7 @@ function DMRootViewModel() {
 
         Notifications.xmpp.pubsub.subscribed.remove(self._updateCurrentNode);
         Notifications.xmpp.pubsub.unsubscribed.remove(self._removeCurrentNode);
+        Notifications.xmpp.disconnected.remove(self._removeCurrentNode);
 
         self.dmCardService.deinit();
     };


### PR DESCRIPTION
### Summary of Changes

- Once an inturruption is detected and the service has been disconnected,
the service attempts to restore the connection using a linear backoff retry
algorithm.
- During XMPP reconnect, the connection object is now recreated. This is
  because of the fact that Strophe plugins do not handle reconnecting the same
object very well, and it's easier to just recreate it. This change leads to a number of issues which have been addressed. The biggest of these issues is that upon disconnect, all connection handlers are dumped by Strophe. This change means that once a reconnect event is detected, the handlers must be re-added. To address this:
  - A new `initialized` notification is fired after the connection is created to allow view
  models to re-add their desired handlers before the connection is actually established to prevent losing events.
  - Recreating the connection first calls `disconnect` to allow VMs to know when
  the connection object will be destroyed.
    - The `disconnected` notification now passes an optional parameter
  `shouldNotify` which informs the UI that a non-automatic disconnect has taken
place and the user should be notified. In the auto-disconnect-reconnect retry
cycle, this parameter is passed as false.

- Adds disconnect notification to party manager.
- Updates root view models to update tabs on disconnect.
- Finally refactors Chat message send to use consistent send method between chat types.


#### Minor Changes

- Fixes issue where `Message.tree` method did not serialize type.
- An unused `send` method was removed from the Chat Service.

### Issues Fixed

None logged for the actual issue, but this should help with #1435 as well.

### Changes Proposed (if any)

None

### Screen Shot of Proposed Changes (if UI related)

None