### PR TITLE
Increases encoutner collapse button hit-box size

### DIFF
--- a/charactersheet/charactersheet/components/nested-list.js
+++ b/charactersheet/charactersheet/components/nested-list.js
@@ -87,7 +87,9 @@ ko.components.register('nested-list', {
                 data-bind="css: $parent.isActiveCSS($data), \
                     click: $parent.selectCell">\
                 <!-- ko if: $data.children && $parent.levels > 0  && children().length > 0 -->\
-                <i data-bind="css: arrowIconClass, click: toggleIsOpen" aria-hidden="true"></i>&nbsp; \
+                <div class="toggle-arrow-container" data-bind="click: toggleIsOpen">\
+                    <i data-bind="css: arrowIconClass" aria-hidden="true"></i>&nbsp; \
+                </div>\
                 <!-- /ko -->\
                 <span data-bind="html: name"></span>&nbsp;&nbsp;\
                 <!-- ko if: $data.badge -->\

--- a/charactersheet/style/site.css
+++ b/charactersheet/style/site.css
@@ -859,3 +859,10 @@ li.image-chat-highlight {
 .circle-indicator.failure {
   background: #e74c3c;
 }
+
+div.toggle-arrow-container {
+  padding-left: 5px;
+  padding-right: 5px;
+  display: inline;
+  text-align: center;
+}


### PR DESCRIPTION
### Summary of Changes

Hit box for collapsing/uncollapsing nested encounters is now bigger to help with usability.

### Issues Fixed

None

### Changes Proposed (if any)

None

### Screen Shot of Proposed Changes (if UI related)

None