### PR TITLE
Characters are no longer dead upon creation.

### DIFF
--- a/charactersheet/charactersheet/viewmodels/character/stats.js
+++ b/charactersheet/charactersheet/viewmodels/character/stats.js
@@ -115,6 +115,7 @@ function StatsViewModel() {
         Notifications.events.longRest.add(self.resetOnLongRest);
         Notifications.armorClass.changed.add(self.updateArmorClass);
         Notifications.abilityScores.changed.add(self._otherStatsDummy.valueHasMutated);
+        self.healthDataHasChange();
     };
 
     self.unload = function() {


### PR DESCRIPTION
### Summary of Changes

Issue was that health and hit dice model didn't exist right after creation, when the status line calculations would happen. Had the calculation fire again when they were loaded in.

### Issues Fixed

Fixes #1490
