### PR TITLE
Add death save success toastr

### DIFF
--- a/charactersheet/charactersheet/viewmodels/character/stats.js
+++ b/charactersheet/charactersheet/viewmodels/character/stats.js
@@ -109,6 +109,9 @@ function StatsViewModel() {
         self.deathSaveFailureList().forEach(function(save, idx, _) {
             save.deathSaveFailure.subscribe(self._alertPlayerHasDied);
         });
+        self.deathSaveSuccessList().forEach(function(save, idx, _) {
+            save.deathSaveSuccess.subscribe(self._alertPlayerIsStable);
+        });
 
         Notifications.profile.changed.add(self._dummy.valueHasMutated);
         Notifications.profile.level.changed.add(self.calculateHitDice);
@@ -391,6 +394,20 @@ function StatsViewModel() {
             Notifications.userNotification.dangerNotification.dispatch(
                 'Failing all 3 death saves will do that...',
                 'You have died.', {
+                    timeOut: 0
+                });
+        }
+
+    };
+
+    self._alertPlayerIsStable = function() {
+        var allSaved = self.deathSaveSuccessList().every(function(save, idx, _) {
+            return save.deathSaveSuccess();
+        });
+        if (allSaved) {
+            Notifications.userNotification.successNotification.dispatch(
+                'You have been spared...for now.',
+                'You are now stable.', {
                     timeOut: 0
                 });
         }


### PR DESCRIPTION
### Summary of Changes

Add death save success toastr

When 3 successes occur, a toastr msg is sent to the players

### Issues Fixed

#1517

### Screen Shot of Proposed Changes (if UI related)

<img width="329" alt="screen shot 2017-08-01 at 8 55 35 pm" src="https://user-images.githubusercontent.com/5814150/28857111-ce01dbda-76fb-11e7-962f-0e133359183a.png">

