### PR TITLE
Feature temp hitpoints

### DIFF
--- a/charactersheet/charactersheet/models/character/health.js
+++ b/charactersheet/charactersheet/models/character/health.js
@@ -16,25 +16,19 @@ function Health() {
     self.damage = ko.observable(0);
 
     self.hitpoints = ko.pureComputed(function() {
-        var damage = self.damage() ? self.damage() : 0;
-        return self.totalHitpoints() - damage;
+        return parseInt(self.regularHitpointsRemaining()) + parseInt(self.tempHitpointsRemaining());
     }, self);
 
     self.totalHitpoints = ko.pureComputed(function() {
-        var maxHP = self.maxHitpoints() ? self.maxHitpoints() : 0;
-        var tempHP = self.tempHitpoints() ? self.tempHitpoints() : 0;
-        return parseInt(maxHP) + parseInt(tempHP);
+        return parseInt(self.maxHitpoints()) + parseInt(self.tempHitpoints());
     }, self);
 
     self.tempHitpointsRemaining = ko.pureComputed(function() {
-        return (parseInt(self.tempHitpoints()) - parseInt(self.damage()));
+        return (parseInt(self.tempHitpoints()));
     }, self);
 
     self.regularHitpointsRemaining = ko.pureComputed(function() {
-        if (self.tempHitpointsRemaining() > 0) {
-            return parseInt(self.maxHitpoints());
-        }
-        return (parseInt(self.maxHitpoints()) - ((self.damage() ? parseInt(self.damage()) : 0) - parseInt(self.tempHitpoints())));
+        return parseInt(self.maxHitpoints()) - parseInt(self.damage());
     }, self);
 
     //Progress bar methods.

--- a/charactersheet/charactersheet/templates/character/stats.tmpl.html
+++ b/charactersheet/charactersheet/templates/character/stats.tmpl.html
@@ -48,7 +48,7 @@
             </tr>
           </tbody>
         </table>
-        <div class="row row-padded" data-bind="visible: health().damage() === health().totalHitpoints()">
+        <div class="row row-padded" data-bind="visible: health().isKnockedOut">
           <div class="col-md-6 col-sm-12 col-padded">
             <div class="input-group">
               <span class="input-group-addon">Death Save Successes</span>

--- a/charactersheet/charactersheet/templates/character/stats.tmpl.html
+++ b/charactersheet/charactersheet/templates/character/stats.tmpl.html
@@ -36,7 +36,7 @@
                   <span data-bind="text: health().maxHitpoints"></span>
               </td>
               <td>
-                <plus-minus params="value: health().damage,
+                <plus-minus params="value: damageHandler,
                   max: health().totalHitpoints">
                   </plus-minus>
               </td>
@@ -48,20 +48,7 @@
             </tr>
           </tbody>
         </table>
-        <div class="input-group">
-          <span class="input-group-addon">Hit Dice:</span>
-          <div class="form-control hit-dice-list">
-            <!-- ko foreach: hitDiceList -->
-            <span data-bind="attr: { id: $index, name: $index },
-              css: hitDiceIcon, click: toggleHitDice"></span>
-            <!-- /ko -->
-            <!-- ko if: hitDiceList().length == 0 -->
-            <span class="hit-dice-list-empty-fill">&nbsp;</span>
-            <!-- /ko -->
-          </div>
-        </div>
-        <br />
-        <div class="row row-padded">
+        <div class="row row-padded" data-bind="visible: health().damage() === health().totalHitpoints()">
           <div class="col-md-6 col-sm-12 col-padded">
             <div class="input-group">
               <span class="input-group-addon">Death Save Successes</span>
@@ -81,7 +68,20 @@
             </div>
           </div>
         </div>
+        <br />
+        <div class="input-group">
+          <span class="input-group-addon">Hit Dice:</span>
+          <div class="form-control hit-dice-list">
+            <!-- ko foreach: hitDiceList -->
+            <span data-bind="attr: { id: $index, name: $index },
+              css: hitDiceIcon, click: toggleHitDice"></span>
+            <!-- /ko -->
+            <!-- ko if: hitDiceList().length == 0 -->
+            <span class="hit-dice-list-empty-fill">&nbsp;</span>
+            <!-- /ko -->
+          </div>
         </div>
+      </div>
       </div>
     </div>
   </div>

--- a/charactersheet/charactersheet/viewmodels/character/stats.js
+++ b/charactersheet/charactersheet/viewmodels/character/stats.js
@@ -23,6 +23,29 @@ function StatsViewModel() {
     self.proficiencyPopover = ko.observable();
     self.armorClassPopover = ko.observable();
 
+    self.damageHandler = ko.computed({
+      read: function() {
+        return self.health().damage()},
+      write: function(value) {
+        if (self.health().tempHitpoints()) {
+           var damageChange = value - self.health().damage();
+           if (damageChange > 0) {
+             var remainingTempHP = self.health().tempHitpoints() - damageChange;
+             if (remainingTempHP >= 0 ) {
+               self.health().tempHitpoints(remainingTempHP);
+               value = self.health().damage();
+             } else {
+               self.health().tempHitpoints(0);
+               value = self.health().damage() + remainingTempHP; // remainingTempHP is negative.
+             }
+           }
+        }
+        self.health().damage(value);
+      },
+      owner: self,
+    });
+
+
     self.load = function() {
         Notifications.global.save.add(self.save);
 

--- a/charactersheet/charactersheet/viewmodels/character/stats.js
+++ b/charactersheet/charactersheet/viewmodels/character/stats.js
@@ -24,25 +24,26 @@ function StatsViewModel() {
     self.armorClassPopover = ko.observable();
 
     self.damageHandler = ko.computed({
-      read: function() {
-        return self.health().damage()},
-      write: function(value) {
-        if (self.health().tempHitpoints()) {
-           var damageChange = value - self.health().damage();
-           if (damageChange > 0) {
-             var remainingTempHP = self.health().tempHitpoints() - damageChange;
-             if (remainingTempHP >= 0 ) {
-               self.health().tempHitpoints(remainingTempHP);
-               value = self.health().damage();
-             } else {
-               self.health().tempHitpoints(0);
-               value = self.health().damage() + remainingTempHP; // remainingTempHP is negative.
-             }
-           }
-        }
-        self.health().damage(value);
-      },
-      owner: self,
+        read: function() {
+            return self.health().damage();
+        },
+        write: function(value) {
+            if (self.health().tempHitpoints()) {
+                var damageChange = value - self.health().damage();
+                if (damageChange > 0) {
+                    var remainingTempHP = self.health().tempHitpoints() - damageChange;
+                    if (remainingTempHP >= 0 ) {
+                        self.health().tempHitpoints(remainingTempHP);
+                        value = self.health().damage();
+                    } else {
+                        value = damageChange - self.health().tempHitpoints();
+                        self.health().tempHitpoints(0);
+                    }
+                }
+            }
+            self.health().damage(value);
+        },
+        owner: self
     });
 
 

--- a/test/viewmodels/test_stats.js
+++ b/test/viewmodels/test_stats.js
@@ -40,7 +40,7 @@ describe('Stats View Model', function() {
                 var stats = new StatsViewModel();
                 stats.health().maxHitpoints(10);
                 stats.health().tempHitpoints(5);
-                stats.health().damage(4);
+                stats.damageHandler(4);
                 stats.health().tempHitpointsRemaining().should.equal(1);
             });
         });
@@ -50,7 +50,8 @@ describe('Stats View Model', function() {
                 var stats = new StatsViewModel();
                 stats.health().maxHitpoints(10);
                 stats.health().tempHitpoints(5);
-                stats.health().damage(8);
+                stats.damageHandler(8);
+                stats.health().tempHitpointsRemaining().should.equal(0);
                 stats.health().regularHitpointsRemaining().should.equal(7);
             });
         });
@@ -60,9 +61,9 @@ describe('Stats View Model', function() {
                 var stats = new StatsViewModel();
                 stats.health().maxHitpoints(10);
                 stats.health().tempHitpoints(5);
-                stats.health().damage(8);
+                stats.damageHandler(8);
                 stats.health().isKnockedOut().should.equal(false);
-                stats.health().damage(15);
+                stats.damageHandler(15);
                 stats.health().isKnockedOut().should.equal(true);
             });
         });
@@ -72,9 +73,9 @@ describe('Stats View Model', function() {
                 var stats = new StatsViewModel();
                 stats.health().maxHitpoints(10);
                 stats.health().tempHitpoints(5);
-                stats.health().damage(8);
+                stats.damageHandler(8);
                 stats.health().isDangerous().should.equal(false);
-                stats.health().damage(14);
+                stats.damageHandler(14);
                 stats.health().isDangerous().should.equal(true);
             });
         });
@@ -84,9 +85,9 @@ describe('Stats View Model', function() {
                 var stats = new StatsViewModel();
                 stats.health().maxHitpoints(10);
                 stats.health().tempHitpoints(5);
-                stats.health().damage(6);
+                stats.damageHandler(6);
                 stats.health().isWarning().should.equal(false);
-                stats.health().damage(8);
+                stats.damageHandler(8);
                 stats.health().isWarning().should.equal(true);
             });
         });
@@ -96,11 +97,11 @@ describe('Stats View Model', function() {
                 var stats = new StatsViewModel();
                 stats.health().maxHitpoints(10);
                 stats.health().tempHitpoints(5);
-                stats.health().damage(6);
+                stats.damageHandler(6);
                 stats.health().progressType().should.equal('progress-bar-success');
-                stats.health().damage(8);
+                stats.damageHandler(7);
                 stats.health().progressType().should.equal('progress-bar-warning');
-                stats.health().damage(11);
+                stats.damageHandler(9);
                 stats.health().progressType().should.equal('progress-bar-danger');
             });
         });
@@ -110,11 +111,11 @@ describe('Stats View Model', function() {
                 var stats = new StatsViewModel();
                 stats.health().maxHitpoints(10);
                 stats.health().tempHitpoints(5);
-                stats.health().damage(13);
+                stats.damageHandler(13);
                 var e = stats.health().exportValues();
                 e.maxHitpoints.should.equal(10);
-                e.tempHitpoints.should.equal(5);
-                e.damage.should.equal(13);
+                e.tempHitpoints.should.equal(0);
+                e.damage.should.equal(8);
             });
         });
 


### PR DESCRIPTION
### Summary of Changes
- Damage is applied to temporary hit points before normal hit points.
- Damage remains even when adding temporary hit points.
- Healing damage does not impact temporary hit points.
- Death saving throws are hidden when the players is conscious.

### Issues Fixed

### Changes Proposed (if any)

### Screen Shot of Proposed Changes (if UI related)
![temp_hit_points](https://user-images.githubusercontent.com/1039347/30727428-00c501f0-9f06-11e7-9cb7-86f0fb748a0f.gif)

