### PR TITLE
Removes Isparta-Loader for now since it was messing up imports.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,3 @@ script:
   - ./scripts/deploy.sh
 after_script:
   - npm run coveralls
-  - mr-doc -s charactersheet/charactersheet/ -o docs/ -n "CharacterSheet" -t "cayman"

--- a/charactersheet/charactersheet/init.js
+++ b/charactersheet/charactersheet/init.js
@@ -31,7 +31,7 @@ import ko from 'knockout';
  */
 export var init = function(viewModel) {
     // Always ignore values in this list when mapping.
-//     ko.mapping.defaultOptions().ignore = Settings.mappingAlwaysIgnore;
+    ko.mapping.defaultOptions().ignore = Settings.mappingAlwaysIgnore;
 
     // Set global URI settings.
     URI.fragmentPrefix = '';

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,6 +2,13 @@ var path = require('path');
 var webpackConfig = require('./webpack.dev');
 var entry = path.resolve(webpackConfig.context, webpackConfig.entry);
 
+webpack = webpackConfig;
+webpack.module.rules.push({
+    test: /\.js$/,
+    loader: "isparta-loader",
+    exclude: /node_modules|bin|test$/ // exclude node_modules and test files
+})
+
 module.exports = function(config) {
     config.set({
         autoWatch: false,
@@ -36,6 +43,6 @@ module.exports = function(config) {
         webpackMiddleware: {
           stats: 'errors-only'
         },
-        webpack: webpackConfig
+        webpack: webpack
     });
 };

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -65,11 +65,6 @@ module.exports = {
         test: /\.(ttf|eot)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
         loader: "file-loader"
       },
-//      {
-//         test: /\.js$/,
-//         loader: "isparta-loader",
-//         exclude: /node_modules|bin|test$/ // exclude node_modules and test files
-//       }
     ],
   },
   externals: {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -65,11 +65,11 @@ module.exports = {
         test: /\.(ttf|eot)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
         loader: "file-loader"
       },
-      {
-        test: /\.js$/,
-        loader: "isparta-loader",
-        exclude: /node_modules|bin|test$/ // exclude node_modules and test files
-      }
+//      {
+//         test: /\.js$/,
+//         loader: "isparta-loader",
+//         exclude: /node_modules|bin|test$/ // exclude node_modules and test files
+//       }
     ],
   },
   externals: {


### PR DESCRIPTION
### Summary of Changes

- The app boots again.
- Removes Isparta-Loader for now since it was messing up imports.
- Adds KO mapping ignore back to init. It was commented out for some reason.

**Note** we might want to [look at this new plugin instead of isparta](https://github.com/webpack-contrib/istanbul-instrumenter-loader#install) since isparta is deprecated.

### Issues Fixed

None Logged

### Changes Proposed (if any)

None

### Screen Shot of Proposed Changes (if UI related)

None