### PR TITLE
Removes legacy bower file.

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,0 @@
-{
-  "directory": "charactersheet/bower_components"
-}


### PR DESCRIPTION
### Summary of Changes

We don't need a `.bowerrc` anymore.

### Issues Fixed

None

### Changes Proposed (if any)

None

### Screen Shot of Proposed Changes (if UI related)

None
