### PR TITLE
Changes the Character Manager to save it's current character to the URL.

### DIFF
--- a/src/charactersheet/utilities/character_manager.js
+++ b/src/charactersheet/utilities/character_manager.js
@@ -14,6 +14,7 @@ import URI from 'urijs';
 export var CharacterManager = {
     __activeCharacter__: null,
     CHARACTER_ID_FRAGMENT_KEY: 'c',
+    CHARACTER_ID_NULL_FRAGMENT: '',
 
     /**
      * Do Initial Character Manager Setup.
@@ -21,7 +22,7 @@ export var CharacterManager = {
      * Note: The Character Manager init must be called for the character manager
      * to detect any character IDs in the URL.
      */
-    init: function() {
+    init: () => {
         var fragments = (new URI()).fragment(true);
         var key = fragments[CharacterManager.CHARACTER_ID_FRAGMENT_KEY];
         if (key) {
@@ -38,7 +39,7 @@ export var CharacterManager = {
      * Note: This method will dispatch notifications to the rest of the app
      * to notify others of this change.
      */
-    changeCharacter: function(characterId) {
+    changeCharacter: (characterId) => {
         var newCharacter = PersistenceService.findFirstBy(Character, 'key', characterId);
         try {
             Notifications.characterManager.changing.dispatch(
@@ -58,7 +59,7 @@ export var CharacterManager = {
     /**
      * Fetch the current Active Character if there is one.
      */
-    activeCharacter: function() {
+    activeCharacter: () => {
         if (CharacterManager.__activeCharacter__) {
             return CharacterManager.__activeCharacter__;
         } else {
@@ -67,18 +68,31 @@ export var CharacterManager = {
     },
 
     /**
+     * Sets the current URL fragment to the given key, or clears the fragment
+     * if the given key is null.
+     *
+     * Note: Deleting the URL fragment entirely causes a page refresh, so instead
+     * we set the fragment to some empty value.
+     */
+    setActiveCharacterFragment: (key) => {
+        var uri = new URI();
+        uri.removeFragment(CharacterManager.CHARACTER_ID_FRAGMENT_KEY);
+
+        key = key ? key : CharacterManager.CHARACTER_ID_NULL_FRAGMENT;
+
+        uri.addFragment(
+            CharacterManager.CHARACTER_ID_FRAGMENT_KEY,
+            key
+        );
+        window.location = uri.toString();
+    },
+
+    /**
      * Sets the character id fragment in the URL and the full
      * character to internal storage.
      */
-    _setActiveCharacter: function(character) {
-        var uri = new URI();
-        uri.removeFragment(CharacterManager.CHARACTER_ID_FRAGMENT_KEY);
-        uri.addFragment(
-            CharacterManager.CHARACTER_ID_FRAGMENT_KEY,
-            character.key()
-        );
-        window.location = uri.toString();
-
+    _setActiveCharacter: (character) => {
+        CharacterManager.setActiveCharacterFragment(character.key());
         CharacterManager.__activeCharacter__ = character;
     }
 };

--- a/src/charactersheet/utilities/character_manager.js
+++ b/src/charactersheet/utilities/character_manager.js
@@ -3,28 +3,62 @@
 import { Character } from 'charactersheet/models/common/character';
 import { Notifications } from 'charactersheet/utilities/notifications';
 import { PersistenceService } from 'charactersheet/services/common/persistence_service';
+import URI from 'urijs';
+
 
 export var CharacterManager = {
-    __activeCharacter__: null
-};
+    __activeCharacter__: null,
+    CHARACTER_ID_FRAGMENT_KEY: 'c',
 
-CharacterManager.changeCharacter = function(characterId) {
-    var newChar = PersistenceService.findFirstBy(Character, 'key', characterId);
-    try {
-        Notifications.characterManager.changing
-            .dispatch(CharacterManager.activeCharacter(), newChar);
-        CharacterManager.__activeCharacter__ = newChar;
-        Notifications.characterManager.changed
-            .dispatch(CharacterManager.activeCharacter());
-    } catch(err) {
-        console.log(err);
-    }
-};
 
-CharacterManager.activeCharacter = function() {
-    if (CharacterManager.__activeCharacter__) {
-        return CharacterManager.__activeCharacter__;
-    } else {
-        return null;
+    init: function() {
+        var fragments = (new URI()).fragment(true);
+        var key = fragments[CharacterManager.CHARACTER_ID_FRAGMENT_KEY];
+        if (key) {
+            var character = PersistenceService.findFirstBy(Character, 'key', key);
+            if (character) {
+                CharacterManager._setActiveCharacter(character);
+            }
+        }
+    },
+
+
+    changeCharacter: function(characterId) {
+        var newCharacter = PersistenceService.findFirstBy(Character, 'key', characterId);
+        try {
+            Notifications.characterManager.changing.dispatch(
+                CharacterManager.activeCharacter(),
+                newCharacter
+            );
+            CharacterManager._setActiveCharacter(newCharacter);
+
+            Notifications.characterManager.changed.dispatch(
+                CharacterManager.activeCharacter()
+            );
+        } catch(err) {
+            console.log(err);
+        }
+    },
+
+
+    activeCharacter: function() {
+        if (CharacterManager.__activeCharacter__) {
+            return CharacterManager.__activeCharacter__;
+        } else {
+            return null;
+        }
+    },
+
+
+    _setActiveCharacter: function(character) {
+        var uri = new URI();
+        uri.removeFragment(CharacterManager.CHARACTER_ID_FRAGMENT_KEY);
+        uri.addFragment(
+            CharacterManager.CHARACTER_ID_FRAGMENT_KEY,
+            character.key()
+        );
+        window.location = uri.toString();
+
+        CharacterManager.__activeCharacter__ = character;
     }
 };

--- a/src/charactersheet/utilities/character_manager.js
+++ b/src/charactersheet/utilities/character_manager.js
@@ -5,12 +5,22 @@ import { Notifications } from 'charactersheet/utilities/notifications';
 import { PersistenceService } from 'charactersheet/services/common/persistence_service';
 import URI from 'urijs';
 
-
+/**
+ * The Character Manager is responsible for determining and alerting others of
+ * changes regarding the current active character that the user wishes to interact
+ * with. It is also responsible for setting the current character ID to the URL fragment
+ * and parsing the URL fragments at launch.
+ */
 export var CharacterManager = {
     __activeCharacter__: null,
     CHARACTER_ID_FRAGMENT_KEY: 'c',
 
-
+    /**
+     * Do Initial Character Manager Setup.
+     *
+     * Note: The Character Manager init must be called for the character manager
+     * to detect any character IDs in the URL.
+     */
     init: function() {
         var fragments = (new URI()).fragment(true);
         var key = fragments[CharacterManager.CHARACTER_ID_FRAGMENT_KEY];
@@ -22,7 +32,12 @@ export var CharacterManager = {
         }
     },
 
-
+    /**
+     * Change the active character to the character with the given ID.
+     *
+     * Note: This method will dispatch notifications to the rest of the app
+     * to notify others of this change.
+     */
     changeCharacter: function(characterId) {
         var newCharacter = PersistenceService.findFirstBy(Character, 'key', characterId);
         try {
@@ -40,7 +55,9 @@ export var CharacterManager = {
         }
     },
 
-
+    /**
+     * Fetch the current Active Character if there is one.
+     */
     activeCharacter: function() {
         if (CharacterManager.__activeCharacter__) {
             return CharacterManager.__activeCharacter__;
@@ -49,7 +66,10 @@ export var CharacterManager = {
         }
     },
 
-
+    /**
+     * Sets the character id fragment in the URL and the full
+     * character to internal storage.
+     */
     _setActiveCharacter: function(character) {
         var uri = new URI();
         uri.removeFragment(CharacterManager.CHARACTER_ID_FRAGMENT_KEY);

--- a/src/charactersheet/viewmodels/common/character_picker/index.js
+++ b/src/charactersheet/viewmodels/common/character_picker/index.js
@@ -23,17 +23,6 @@ export function CharacterPickerViewModel(params) {
     self.defaultCharacterKey = ko.observable(null);
     self.state = params.state;
 
-// TODO: Move to Load if required.
-//     self.init = function() {
-//         Notifications.characters.changed.add(function() {
-//             self.load();
-//         });
-//         Notifications.profile.changed.add(function() {
-//             self.load();
-//         });
-//         Notifications.user.exists.add(self._handleUserChanged);
-//     };
-
     self.load = function() {
         self.characters(PersistenceService.findAll(Character));
     };

--- a/src/charactersheet/viewmodels/common/root/index.js
+++ b/src/charactersheet/viewmodels/common/root/index.js
@@ -103,8 +103,13 @@ export function AdventurersCodexViewModel() {
         Notifications.characterManager.changing.add(self._handleChangingCharacter);
         Notifications.characterManager.changed.add(self._handleChangedCharacter);
 
+        CharacterManager.init();
         var characters = PersistenceService.findAll(Character);
-        if (characters.length > 0) {
+
+        if (CharacterManager.activeCharacter()) {
+            // There might be an active character in the URL.
+            self._handleChangedCharacter();
+        } else if (characters.length > 0) {
             self.state(APP_STATE.SELECT);
         } else {
             //If no current character exists, fire the load process anyway.

--- a/src/charactersheet/viewmodels/common/wizard/index.js
+++ b/src/charactersheet/viewmodels/common/wizard/index.js
@@ -53,6 +53,8 @@ export function WizardViewModel() {
     self.init = function() { };
 
     self.load = function() {
+        CharacterManager.setActiveCharacterFragment(null);
+
         self.getNextStep();
         self.goForward();
     };


### PR DESCRIPTION
**IMPORTANT: Looking for feedback on this. Not immediately for merge.**

### Summary of Changes

- The Character Manager now uses the URL fragments as a store for the current character ID. This means that upon Application Load, we can first check the URL for an active character and load that instead of asking the user to choose.
- The AdventurersCodexViewModel is now aware of the new functions of the Character Manager.
- The Character Manager now has full documentation. 🎉🎉

#### Sample URL w/ new ID fragment

```
/charactersheet/#c=233f2e75-ff33-48b6-b395-cee9f76cd669
```
### Issues Fixed

Fixes #1600 

### Changes Proposed (if any)

Characters/Games can now be bookmarked and saved by the user's browser, and refreshing the page no longer shoots the user back to the picker screen.

### Screen Shot of Proposed Changes (if UI related)

None

### Edits
- 2017-12-04: Adds sample URL and emoji to PR notes. 