### PR TITLE
Encounter Names and Locations Now Save

### DIFF
--- a/src/charactersheet/components/nested-list.js
+++ b/src/charactersheet/components/nested-list.js
@@ -27,6 +27,9 @@ export function NestedListComponentViewModel(params) {
 
     self.cells = params.cells || ko.observableArray();
     self.selectedCell = params.selectedCell || ko.observable();
+
+    // Callback Handlers
+    self.onselect = params.onselect;
     self.ondelete = params.ondelete;
     self.onadd = params.onadd;
 
@@ -38,6 +41,9 @@ export function NestedListComponentViewModel(params) {
 
     self.selectCell = function(cell) {
         self.selectedCell(cell);
+        if (self.onselect) {
+            self.onselect(cell);
+        }
     };
 
     /**
@@ -116,7 +122,8 @@ ko.components.register('nested-list', {
                         levels: $parent.levels - 1, \
                         selectedCell: $parent.selectedCell, \
                         onadd: $parent.onadd, \
-                        ondelete: $parent.ondelete"></nested-list>\
+                        ondelete: $parent.ondelete, \
+                        onselect: $parent.onselect"></nested-list>\
                 </div>\
             </div>\
             <!-- /ko -->\

--- a/src/charactersheet/models/dm/encounter.js
+++ b/src/charactersheet/models/dm/encounter.js
@@ -46,13 +46,21 @@ export function Encounter() {
      * Returns the list of encounter objects corresponding to the child ids.
      */
     self.getChildren = function() {
+        var key = CharacterManager.activeCharacter().key();
         return self.children().map(function(id, idx, _) {
-            return PersistenceService.findFirstBy(Encounter, 'encounterId', id);
+            return PersistenceService.findByPredicates(Encounter, [
+                new KeyValuePredicate('encounterId', id,
+                new KeyValuePredicate('characterId', key,
+            ])[0];
         });
     };
 
     self.getParent = function() {
-        return PersistenceService.findFirstBy(Encounter, 'encounterId', self.parent());
+        var key = CharacterManager.activeCharacter().key();
+        return PersistenceService.findByPredicates(Encounter, [
+            new KeyValuePredicate('encounterId', self.parent()),
+            new KeyValuePredicate('characterId', key,
+        ])[0];
     };
 
     /* View Model Methods */

--- a/src/charactersheet/models/dm/encounter.js
+++ b/src/charactersheet/models/dm/encounter.js
@@ -1,6 +1,6 @@
 import { CharacterManager } from 'charactersheet/utilities';
-import { PersistenceService } from 'charactersheet/services/common/persistence_service';
 import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';
+import { PersistenceService } from 'charactersheet/services/common/persistence_service';
 import ko from 'knockout';
 import uuid from 'node-uuid';
 
@@ -61,7 +61,7 @@ export function Encounter() {
         var key = CharacterManager.activeCharacter().key();
         return PersistenceService.findByPredicates(Encounter, [
             new KeyValuePredicate('encounterId', self.parent()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
     };
 

--- a/src/charactersheet/models/dm/encounter.js
+++ b/src/charactersheet/models/dm/encounter.js
@@ -1,4 +1,6 @@
+import { CharacterManager } from 'charactersheet/utilities';
 import { PersistenceService } from 'charactersheet/services/common/persistence_service';
+import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';
 import ko from 'knockout';
 import uuid from 'node-uuid';
 
@@ -49,8 +51,8 @@ export function Encounter() {
         var key = CharacterManager.activeCharacter().key();
         return self.children().map(function(id, idx, _) {
             return PersistenceService.findByPredicates(Encounter, [
-                new KeyValuePredicate('encounterId', id,
-                new KeyValuePredicate('characterId', key,
+                new KeyValuePredicate('encounterId', id),
+                new KeyValuePredicate('characterId', key)
             ])[0];
         });
     };
@@ -59,7 +61,7 @@ export function Encounter() {
         var key = CharacterManager.activeCharacter().key();
         return PersistenceService.findByPredicates(Encounter, [
             new KeyValuePredicate('encounterId', self.parent()),
-            new KeyValuePredicate('characterId', key,
+            new KeyValuePredicate('characterId', key),
         ])[0];
     };
 

--- a/src/charactersheet/viewmodels/dm/encounter/index.html
+++ b/src/charactersheet/viewmodels/dm/encounter/index.html
@@ -19,7 +19,7 @@
             </div>
             <nested-list params="cells: encounterCells,
               selectedCell: selectedCell, ondelete: deleteEncounter,
-              onadd: openAddModalWithParent">
+              onadd: openAddModalWithParent, onselect: selectEncounter">
             </nested-list>
           </div>
         </div>
@@ -42,5 +42,5 @@
 </div>
 
 <encounter-add-edit-modal
-  params="encounter: modalEncounter, openModal: openModal, sections: modalEncounterSections, , onsave: modalSave">
+  params="encounter: modalEncounter, openModal: openModal, sections: modalEncounterSections, onsave: modalSave">
 </encounter-add-edit-modal>

--- a/src/charactersheet/viewmodels/dm/encounter/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter/index.js
@@ -13,9 +13,9 @@ import {
     PointOfInterestSection,
     TreasureSection
 } from 'charactersheet/models/dm';
-import { EncounterCellViewModel } from 'charactersheet/viewmodels/dm/encounter_cell';
-import { PersistenceService } from 'charactersheet/services/common/persistence_service';
+import { EncounterCellViewModel } from 'charactersheet/viewmodels/dm';
 import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';
+import { PersistenceService } from 'charactersheet/services/common/persistence_service';
 import ko from 'knockout';
 import template from './index.html';
 
@@ -126,7 +126,7 @@ export function EncounterViewModel() {
         var key = CharacterManager.activeCharacter().key();
         var encounter = PersistenceService.findByPredicates(Encounter, [
             new KeyValuePredicate('encounterId', cell.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
 
         var parentCell = self._findCell(self.encounterCells(), 'encounterId', encounter.parent());
@@ -136,7 +136,7 @@ export function EncounterViewModel() {
 
         var parentEncounter =  PersistenceService.findByPredicates(Encounter, [
             new KeyValuePredicate('encounterId', encounter.parent()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         if (parentEncounter) {
             parentEncounter.removeChild(encounter.encounterId());
@@ -156,7 +156,7 @@ export function EncounterViewModel() {
     self._getEncounterCells = function() {
         var key = CharacterManager.activeCharacter().key();
         var allEncounters = PersistenceService.findByPredicates(Encounter, [
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ]);
         var topLevel = allEncounters.filter(function(enc, idx, _) {
             return !enc.parent();
@@ -187,7 +187,7 @@ export function EncounterViewModel() {
             var key = CharacterManager.activeCharacter().key();
             var section =  PersistenceService.findByPredicates(sectionModel.model, [
                 new KeyValuePredicate('encounterId', id),
-                new KeyValuePredicate('characterId', key),
+                new KeyValuePredicate('characterId', key)
             ])[0];
             if (!section) {
                 section = new sectionModel.model();
@@ -209,11 +209,11 @@ export function EncounterViewModel() {
             self.selectedEncounter(null);
         }
 
-        var id = self.selectedCell().encounterId()
+        var id = self.selectedCell().encounterId();
         var key = CharacterManager.activeCharacter().key();
         var selectedEncounter = PersistenceService.findByPredicates(Encounter, [
             new KeyValuePredicate('encounterId', id),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         if (selectedEncounter) {
             self.selectedEncounter(selectedEncounter);

--- a/src/charactersheet/viewmodels/dm/encounter/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter/index.js
@@ -15,6 +15,7 @@ import {
 } from 'charactersheet/models/dm';
 import { EncounterCellViewModel } from 'charactersheet/viewmodels/dm/encounter_cell';
 import { PersistenceService } from 'charactersheet/services/common/persistence_service';
+import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';
 import ko from 'knockout';
 import template from './index.html';
 
@@ -31,7 +32,7 @@ export function EncounterViewModel() {
         var key = CharacterManager.activeCharacter().key();
         return PersistenceService.findByPredicates(Encounter, [
             new KeyValuePredicate('encounterId', self.selectedCell().encounterId()),
-            new KeyValuePredicate('characterId', key,
+            new KeyValuePredicate('characterId', key),
         ])[0];
     });
 
@@ -124,7 +125,7 @@ export function EncounterViewModel() {
         var key = CharacterManager.activeCharacter().key();
         var encounter = PersistenceService.findByPredicates(Encounter, [
             new KeyValuePredicate('encounterId', cell.encounterId()),
-            new KeyValuePredicate('characterId', key,
+            new KeyValuePredicate('characterId', key),
         ])[0];
 
         var parentCell = self._findCell(self.encounterCells(), 'encounterId', encounter.parent());
@@ -134,7 +135,7 @@ export function EncounterViewModel() {
 
         var parentEncounter =  PersistenceService.findByPredicates(Encounter, [
             new KeyValuePredicate('encounterId', encounter.parent()),
-            new KeyValuePredicate('characterId', key,
+            new KeyValuePredicate('characterId', key),
         ])[0];
         if (parentEncounter) {
             parentEncounter.removeChild(encounter.encounterId());
@@ -152,7 +153,9 @@ export function EncounterViewModel() {
 
     self._getEncounterCells = function() {
         var key = CharacterManager.activeCharacter().key();
-        var allEncounters = PersistenceService.findBy(Encounter, 'characterId', key);
+        var allEncounters = PersistenceService.findByPredicates(Encounter, [
+            new KeyValuePredicate('characterId', key),
+        ]);
         var topLevel = allEncounters.filter(function(enc, idx, _) {
             return !enc.parent();
         });
@@ -182,7 +185,7 @@ export function EncounterViewModel() {
             var key = CharacterManager.activeCharacter().key();
             var section =  PersistenceService.findByPredicates(sectionModel.model, [
                 new KeyValuePredicate('encounterId', id),
-                new KeyValuePredicate('characterId', key,
+                new KeyValuePredicate('characterId', key),
             ])[0];
             if (!section) {
                 section = new sectionModel.model();

--- a/src/charactersheet/viewmodels/dm/encounter_add_edit_modal/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_add_edit_modal/index.js
@@ -1,7 +1,7 @@
 import { Encounter } from 'charactersheet/models/dm';
+import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';
 import { Notifications } from 'charactersheet/utilities';
 import { PersistenceService } from 'charactersheet/services/common/persistence_service';
-import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';
 import ko from 'knockout';
 import template from './index.html';
 

--- a/src/charactersheet/viewmodels/dm/encounter_add_edit_modal/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_add_edit_modal/index.js
@@ -1,6 +1,7 @@
 import { Encounter } from 'charactersheet/models/dm';
 import { Notifications } from 'charactersheet/utilities';
 import { PersistenceService } from 'charactersheet/services/common/persistence_service';
+import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';
 import ko from 'knockout';
 import template from './index.html';
 

--- a/src/charactersheet/viewmodels/dm/encounter_cell/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_cell/index.js
@@ -1,3 +1,4 @@
+import { CharacterManager } from 'charactersheet/utilities/character_manager'
 import { Encounter } from 'charactersheet/models/dm';
 import { PersistenceService } from 'charactersheet/services/common/persistence_service';
 import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';

--- a/src/charactersheet/viewmodels/dm/encounter_cell/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_cell/index.js
@@ -1,7 +1,7 @@
-import { CharacterManager } from 'charactersheet/utilities/character_manager'
+import { CharacterManager } from 'charactersheet/utilities/character_manager';
 import { Encounter } from 'charactersheet/models/dm';
-import { PersistenceService } from 'charactersheet/services/common/persistence_service';
 import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';
+import { PersistenceService } from 'charactersheet/services/common/persistence_service';
 import { ViewModelUtilities } from 'charactersheet/utilities';
 import ko from 'knockout';
 
@@ -45,7 +45,7 @@ export function EncounterCellViewModel(encounter) {
         var key = CharacterManager.activeCharacter().key();
         var encounter =  PersistenceService.findByPredicates(Encounter, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         encounter.children.push(child.encounterId());
         encounter.save();
@@ -66,7 +66,7 @@ export function EncounterCellViewModel(encounter) {
         var key = CharacterManager.activeCharacter().key();
         var encounter =  PersistenceService.findByPredicates(Encounter, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         encounter.name(self.name());
         encounter.encounterLocation(self.encounterLocation());
@@ -78,7 +78,7 @@ export function EncounterCellViewModel(encounter) {
         var key = CharacterManager.activeCharacter().key();
         var encounter =  PersistenceService.findByPredicates(Encounter, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         encounter.delete();
         self.children().forEach(function(child, idx, _) {
@@ -92,7 +92,7 @@ export function EncounterCellViewModel(encounter) {
         var key = CharacterManager.activeCharacter().key();
         var encounter =  PersistenceService.findByPredicates(Encounter, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         self.name(encounter.name());
         self.encounterLocation(encounter.encounterLocation());

--- a/src/charactersheet/viewmodels/dm/encounter_cell/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_cell/index.js
@@ -40,7 +40,11 @@ export function EncounterCellViewModel(encounter) {
 
     self.addChild = function(child) {
         // Update the data.
-        var encounter = PersistenceService.findFirstBy(Encounter, 'encounterId', self.encounterId());
+        var key = CharacterManager.activeCharacter().key();
+        var encounter =  PersistenceService.findByPredicates(Encounter, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key,
+        ])[0];
         encounter.children.push(child.encounterId());
         encounter.save();
 
@@ -57,7 +61,11 @@ export function EncounterCellViewModel(encounter) {
     /* View Model Methods */
 
     self.save = function() {
-        var encounter = PersistenceService.findFirstBy(Encounter, 'encounterId', self.encounterId());
+        var key = CharacterManager.activeCharacter().key();
+        var encounter =  PersistenceService.findByPredicates(Encounter, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key,
+        ])[0];
         encounter.name(self.name());
         encounter.encounterLocation(self.encounterLocation());
         encounter.isOpen(self.isOpen());
@@ -65,7 +73,11 @@ export function EncounterCellViewModel(encounter) {
     };
 
     self.delete = function() {
-        var encounter = PersistenceService.findFirstBy(Encounter, 'encounterId', self.encounterId());
+        var key = CharacterManager.activeCharacter().key();
+        var encounter =  PersistenceService.findByPredicates(Encounter, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key,
+        ])[0];
         encounter.delete();
         self.children().forEach(function(child, idx, _) {
             child.delete();
@@ -75,7 +87,11 @@ export function EncounterCellViewModel(encounter) {
     /* Data Refresh Methods */
 
     self.reloadData = function() {
-        var encounter = PersistenceService.findFirstBy(Encounter, 'encounterId', self.encounterId());
+        var key = CharacterManager.activeCharacter().key();
+        var encounter =  PersistenceService.findByPredicates(Encounter, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key,
+        ])[0];
         self.name(encounter.name());
         self.encounterLocation(encounter.encounterLocation());
         self.children().forEach(function(child, idx, _) {

--- a/src/charactersheet/viewmodels/dm/encounter_cell/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_cell/index.js
@@ -1,5 +1,6 @@
 import { Encounter } from 'charactersheet/models/dm';
 import { PersistenceService } from 'charactersheet/services/common/persistence_service';
+import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';
 import { ViewModelUtilities } from 'charactersheet/utilities';
 import ko from 'knockout';
 
@@ -43,7 +44,7 @@ export function EncounterCellViewModel(encounter) {
         var key = CharacterManager.activeCharacter().key();
         var encounter =  PersistenceService.findByPredicates(Encounter, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key,
+            new KeyValuePredicate('characterId', key),
         ])[0];
         encounter.children.push(child.encounterId());
         encounter.save();
@@ -64,7 +65,7 @@ export function EncounterCellViewModel(encounter) {
         var key = CharacterManager.activeCharacter().key();
         var encounter =  PersistenceService.findByPredicates(Encounter, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key,
+            new KeyValuePredicate('characterId', key),
         ])[0];
         encounter.name(self.name());
         encounter.encounterLocation(self.encounterLocation());
@@ -76,7 +77,7 @@ export function EncounterCellViewModel(encounter) {
         var key = CharacterManager.activeCharacter().key();
         var encounter =  PersistenceService.findByPredicates(Encounter, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key,
+            new KeyValuePredicate('characterId', key),
         ])[0];
         encounter.delete();
         self.children().forEach(function(child, idx, _) {
@@ -90,7 +91,7 @@ export function EncounterCellViewModel(encounter) {
         var key = CharacterManager.activeCharacter().key();
         var encounter =  PersistenceService.findByPredicates(Encounter, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key,
+            new KeyValuePredicate('characterId', key),
         ])[0];
         self.name(encounter.name());
         self.encounterLocation(encounter.encounterLocation());

--- a/src/charactersheet/viewmodels/dm/encounter_detail/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_detail/index.js
@@ -1,6 +1,8 @@
+import { CharacterManager } from 'charactersheet/utilities';
 import { Encounter } from 'charactersheet/models/dm';
 import { Notifications } from 'charactersheet/utilities';
 import { PersistenceService } from 'charactersheet/services/common/persistence_service';
+import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';
 import ko from 'knockout';
 import template from './index.html';
 
@@ -54,8 +56,8 @@ export function EncounterDetailViewModel(params) {
         var sections = self.sectionModels.map(function(sectionModel, i, _) {
             var key = CharacterManager.activeCharacter().key();
             var section =  PersistenceService.findByPredicates(sectionModel.model, [
-                new KeyValuePredicate('encounterId', id),
-                new KeyValuePredicate('characterId', key,
+                new KeyValuePredicate('encounterId', self.encounter().encounterId()),
+                new KeyValuePredicate('characterId', key),
             ])[0];
             if (!section) {
                 section = new sectionModel.model();

--- a/src/charactersheet/viewmodels/dm/encounter_detail/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_detail/index.js
@@ -27,7 +27,7 @@ export function EncounterDetailViewModel(params) {
      * notify the subscribers.
      */
     self.notifySections = function(encounter, sections) {
-        encounter.save();
+        encounter().save();
 
         sections().forEach(function(section, i, _) {
             section.save();

--- a/src/charactersheet/viewmodels/dm/encounter_detail/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_detail/index.js
@@ -1,8 +1,8 @@
 import { CharacterManager } from 'charactersheet/utilities';
 import { Encounter } from 'charactersheet/models/dm';
+import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';
 import { Notifications } from 'charactersheet/utilities';
 import { PersistenceService } from 'charactersheet/services/common/persistence_service';
-import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';
 import ko from 'knockout';
 import template from './index.html';
 
@@ -57,7 +57,7 @@ export function EncounterDetailViewModel(params) {
             var key = CharacterManager.activeCharacter().key();
             var section =  PersistenceService.findByPredicates(sectionModel.model, [
                 new KeyValuePredicate('encounterId', self.encounter().encounterId()),
-                new KeyValuePredicate('characterId', key),
+                new KeyValuePredicate('characterId', key)
             ])[0];
             if (!section) {
                 section = new sectionModel.model();

--- a/src/charactersheet/viewmodels/dm/encounter_sections/environment_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/environment_section/index.js
@@ -101,7 +101,11 @@ export function EnvironmentSectionViewModel(params) {
     };
 
     self.save = function() {
-        var environment = PersistenceService.findFirstBy(Environment, 'encounterId', self.encounterId());
+        var key = CharacterManager.activeCharacter().key();
+        var environment =  PersistenceService.findByPredicates(Environment, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key,
+        ])[0];
         if (!environment) {
             var key = CharacterManager.activeCharacter().key();
             environment = new Environment();
@@ -117,7 +121,11 @@ export function EnvironmentSectionViewModel(params) {
     };
 
     self.delete = function() {
-        var environment = PersistenceService.findFirstBy(Environment, 'encounterId', self.encounterId());
+        var key = CharacterManager.activeCharacter().key();
+        var environment =  PersistenceService.findByPredicates(Environment, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key,
+        ])[0];
         if (environment) {
             environment.delete();
         }
@@ -183,14 +191,20 @@ export function EnvironmentSectionViewModel(params) {
 
     self._dataHasChanged = function() {
         var key = CharacterManager.activeCharacter().key();
-        var environmentSection = PersistenceService.findFirstBy(EnvironmentSection, 'encounterId', self.encounterId());
+        var environmentSection =  PersistenceService.findByPredicates(EnvironmentSection, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key,
+        ])[0];
         if (environmentSection) {
             self.name(environmentSection.name());
             self.visible(environmentSection.visible());
             self.tagline(environmentSection.tagline());
         }
 
-        var environment = PersistenceService.findFirstBy(Environment, 'encounterId', self.encounterId());
+        var environment =  PersistenceService.findByPredicates(Environment, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key,
+        ])[0];
         if (environment) {
             self.environment(environment);
             self.imageUrl(environment.imageUrl());

--- a/src/charactersheet/viewmodels/dm/encounter_sections/environment_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/environment_section/index.js
@@ -9,6 +9,7 @@ import {
     PersistenceService,
     XMPPService
 } from 'charactersheet/services/common';
+import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';
 import {
     Environment,
     EnvironmentSection,
@@ -104,7 +105,7 @@ export function EnvironmentSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var environment =  PersistenceService.findByPredicates(Environment, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key,
+            new KeyValuePredicate('characterId', key),
         ])[0];
         if (!environment) {
             var key = CharacterManager.activeCharacter().key();
@@ -124,7 +125,7 @@ export function EnvironmentSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var environment =  PersistenceService.findByPredicates(Environment, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key,
+            new KeyValuePredicate('characterId', key),
         ])[0];
         if (environment) {
             environment.delete();
@@ -193,7 +194,7 @@ export function EnvironmentSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var environmentSection =  PersistenceService.findByPredicates(EnvironmentSection, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key,
+            new KeyValuePredicate('characterId', key),
         ])[0];
         if (environmentSection) {
             self.name(environmentSection.name());
@@ -203,7 +204,7 @@ export function EnvironmentSectionViewModel(params) {
 
         var environment =  PersistenceService.findByPredicates(Environment, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key,
+            new KeyValuePredicate('characterId', key),
         ])[0];
         if (environment) {
             self.environment(environment);

--- a/src/charactersheet/viewmodels/dm/encounter_sections/environment_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/environment_section/index.js
@@ -9,12 +9,12 @@ import {
     PersistenceService,
     XMPPService
 } from 'charactersheet/services/common';
-import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';
 import {
     Environment,
     EnvironmentSection,
     Message
 } from 'charactersheet/models/dm';
+import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';
 import Strophe from 'strophe';
 import ko from 'knockout';
 import sectionIcon from 'images/encounters/night-sky.svg';
@@ -105,10 +105,9 @@ export function EnvironmentSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var environment =  PersistenceService.findByPredicates(Environment, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         if (!environment) {
-            var key = CharacterManager.activeCharacter().key();
             environment = new Environment();
             environment.characterId(key);
             environment.encounterId(self.encounterId());
@@ -125,7 +124,7 @@ export function EnvironmentSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var environment =  PersistenceService.findByPredicates(Environment, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         if (environment) {
             environment.delete();
@@ -194,7 +193,7 @@ export function EnvironmentSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var environmentSection =  PersistenceService.findByPredicates(EnvironmentSection, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         if (environmentSection) {
             self.name(environmentSection.name());
@@ -204,7 +203,7 @@ export function EnvironmentSectionViewModel(params) {
 
         var environment =  PersistenceService.findByPredicates(Environment, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         if (environment) {
             self.environment(environment);

--- a/src/charactersheet/viewmodels/dm/encounter_sections/maps_and_images_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/maps_and_images_section/index.js
@@ -89,7 +89,10 @@ export function MapsAndImagesSectionViewModel(params) {
 
     self.save = function() {
         var key = CharacterManager.activeCharacter().key();
-        var section = PersistenceService.findFirstBy(MapsAndImagesSection, 'encounterId', self.encounterId());
+        var section =  PersistenceService.findByPredicates(MapsAndImagesSection, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key,
+        ])[0];
         if (!section) {
             section = new MapsAndImagesSection();
             section.encounterId(self.encounterId());
@@ -106,7 +109,11 @@ export function MapsAndImagesSectionViewModel(params) {
     };
 
     self.delete = function() {
-        var section = PersistenceService.findFirstBy(MapsAndImagesSection, 'encounterId', self.encounterId());
+        var key = CharacterManager.activeCharacter().key();
+        var section =  PersistenceService.findByPredicates(MapsAndImagesSection, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key,
+        ])[0];
         if (section) {
             section.delete();
         }
@@ -229,12 +236,18 @@ export function MapsAndImagesSectionViewModel(params) {
 
     self._dataHasChanged = function() {
         var key = CharacterManager.activeCharacter().key();
-        var map = PersistenceService.findBy(MapOrImage, 'encounterId', self.encounterId());
+        var mapS =  PersistenceService.findByPredicates(MapOrImage, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key,
+        ]);
         if (map) {
-            self.mapsOrImages(map);
+            self.mapsOrImages(mapS);
         }
 
-        var section = PersistenceService.findFirstBy(MapsAndImagesSection, 'encounterId', self.encounterId());
+        var section =  PersistenceService.findByPredicates(MapsAndImagesSection, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key,
+        ])[0];
         if (!section) {
             section = new MapsAndImagesSection();
             section.encounterId(self.encounterId());

--- a/src/charactersheet/viewmodels/dm/encounter_sections/maps_and_images_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/maps_and_images_section/index.js
@@ -10,6 +10,7 @@ import {
     SortService,
     XMPPService
 } from 'charactersheet/services/common';
+import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';
 import {
     MapOrImage,
     Message
@@ -91,7 +92,7 @@ export function MapsAndImagesSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var section =  PersistenceService.findByPredicates(MapsAndImagesSection, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key,
+            new KeyValuePredicate('characterId', key),
         ])[0];
         if (!section) {
             section = new MapsAndImagesSection();
@@ -112,7 +113,7 @@ export function MapsAndImagesSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var section =  PersistenceService.findByPredicates(MapsAndImagesSection, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key,
+            new KeyValuePredicate('characterId', key),
         ])[0];
         if (section) {
             section.delete();
@@ -236,17 +237,17 @@ export function MapsAndImagesSectionViewModel(params) {
 
     self._dataHasChanged = function() {
         var key = CharacterManager.activeCharacter().key();
-        var mapS =  PersistenceService.findByPredicates(MapOrImage, [
+        var map =  PersistenceService.findByPredicates(MapOrImage, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key,
+            new KeyValuePredicate('characterId', key),
         ]);
         if (map) {
-            self.mapsOrImages(mapS);
+            self.mapsOrImages(map);
         }
 
         var section =  PersistenceService.findByPredicates(MapsAndImagesSection, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key,
+            new KeyValuePredicate('characterId', key),
         ])[0];
         if (!section) {
             section = new MapsAndImagesSection();

--- a/src/charactersheet/viewmodels/dm/encounter_sections/maps_and_images_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/maps_and_images_section/index.js
@@ -10,11 +10,11 @@ import {
     SortService,
     XMPPService
 } from 'charactersheet/services/common';
-import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';
 import {
     MapOrImage,
     Message
 } from 'charactersheet/models/common';
+import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';
 import { MapsAndImagesSection } from 'charactersheet/models/dm';
 import ko from 'knockout';
 import sectionIcon from 'images/encounters/globe.svg';
@@ -92,7 +92,7 @@ export function MapsAndImagesSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var section =  PersistenceService.findByPredicates(MapsAndImagesSection, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         if (!section) {
             section = new MapsAndImagesSection();
@@ -113,7 +113,7 @@ export function MapsAndImagesSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var section =  PersistenceService.findByPredicates(MapsAndImagesSection, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         if (section) {
             section.delete();
@@ -239,7 +239,7 @@ export function MapsAndImagesSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var map =  PersistenceService.findByPredicates(MapOrImage, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ]);
         if (map) {
             self.mapsOrImages(map);
@@ -247,7 +247,7 @@ export function MapsAndImagesSectionViewModel(params) {
 
         var section =  PersistenceService.findByPredicates(MapsAndImagesSection, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         if (!section) {
             section = new MapsAndImagesSection();

--- a/src/charactersheet/viewmodels/dm/encounter_sections/monster_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/monster_section/index.js
@@ -80,7 +80,10 @@ export function MonsterSectionViewModel(params) {
 
     self.save = function() {
         var key = CharacterManager.activeCharacter().key();
-        var section = PersistenceService.findFirstBy(MonsterSection, 'encounterId', self.encounterId());
+        var section =  PersistenceService.findByPredicates(MonsterSection, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key,
+        ])[0];
         if (!section) {
             section = new MonsterSection();
             section.encounterId(self.encounterId());
@@ -97,7 +100,11 @@ export function MonsterSectionViewModel(params) {
     };
 
     self.delete = function() {
-        var section = PersistenceService.findFirstBy(MonsterSection, 'encounterId', self.encounterId());
+        var key = CharacterManager.activeCharacter().key();
+        var section =  PersistenceService.findByPredicates(MonsterSection, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key,
+        ])[0];
         if (section) {
             section.delete();
         }
@@ -261,7 +268,10 @@ export function MonsterSectionViewModel(params) {
 
     self._dataHasChanged = function() {
         var key = CharacterManager.activeCharacter().key();
-        var monster = PersistenceService.findBy(Monster, 'encounterId', self.encounterId());
+        var monster =  PersistenceService.findByPredicates(Monster, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key,
+        ]);
         if (monster) {
             self.monsters(monster);
             self.monsters().forEach(function(monster, idx, _) {
@@ -270,8 +280,10 @@ export function MonsterSectionViewModel(params) {
                 monster.abilityScores(abilityScores);
             });
         }
-
-        var section = PersistenceService.findFirstBy(MonsterSection, 'encounterId', self.encounterId());
+        var section =  PersistenceService.findByPredicates(MonsterSection, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key,
+        ])[0];
         if (section) {
             self.name(section.name());
             self.visible(section.visible());

--- a/src/charactersheet/viewmodels/dm/encounter_sections/monster_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/monster_section/index.js
@@ -83,7 +83,7 @@ export function MonsterSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var section =  PersistenceService.findByPredicates(MonsterSection, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         if (!section) {
             section = new MonsterSection();
@@ -104,7 +104,7 @@ export function MonsterSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var section =  PersistenceService.findByPredicates(MonsterSection, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         if (section) {
             section.delete();
@@ -271,7 +271,7 @@ export function MonsterSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var monster =  PersistenceService.findByPredicates(Monster, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ]);
         if (monster) {
             self.monsters(monster);
@@ -283,7 +283,7 @@ export function MonsterSectionViewModel(params) {
         }
         var section =  PersistenceService.findByPredicates(MonsterSection, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         if (section) {
             self.name(section.name());

--- a/src/charactersheet/viewmodels/dm/encounter_sections/monster_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/monster_section/index.js
@@ -12,6 +12,7 @@ import {
     PersistenceService,
     SortService
 } from 'charactersheet/services';
+import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';
 import ko from 'knockout';
 import sectionIcon from 'images/encounters/wyvern.svg';
 import template from './index.html';
@@ -82,7 +83,7 @@ export function MonsterSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var section =  PersistenceService.findByPredicates(MonsterSection, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key,
+            new KeyValuePredicate('characterId', key),
         ])[0];
         if (!section) {
             section = new MonsterSection();
@@ -103,7 +104,7 @@ export function MonsterSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var section =  PersistenceService.findByPredicates(MonsterSection, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key,
+            new KeyValuePredicate('characterId', key),
         ])[0];
         if (section) {
             section.delete();
@@ -270,7 +271,7 @@ export function MonsterSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var monster =  PersistenceService.findByPredicates(Monster, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key,
+            new KeyValuePredicate('characterId', key),
         ]);
         if (monster) {
             self.monsters(monster);
@@ -282,7 +283,7 @@ export function MonsterSectionViewModel(params) {
         }
         var section =  PersistenceService.findByPredicates(MonsterSection, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key,
+            new KeyValuePredicate('characterId', key),
         ])[0];
         if (section) {
             self.name(section.name());

--- a/src/charactersheet/viewmodels/dm/encounter_sections/notes_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/notes_section/index.js
@@ -4,6 +4,7 @@ import {
 } from 'charactersheet/utilities';
 import { NotesSection } from 'charactersheet/models';
 import { PersistenceService } from 'charactersheet/services/common/persistence_service';
+import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';
 import ko from 'knockout';
 import sectionIcon from 'images/encounters/quill-ink.svg';
 import template from './index.html';
@@ -39,7 +40,11 @@ export function NotesSectionViewModel(params) {
     };
 
     self.unload = function() {
-        var notes = PersistenceService.findFirstBy(NotesSection, 'encounterId', self.encounterId());
+        var key = CharacterManager.activeCharacter().key();
+        var notes = PersistenceService.findByPredicates(NotesSection, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key),
+        ])[0];
         if (!notes) {
             notes = new NotesSection();
         }
@@ -53,7 +58,11 @@ export function NotesSectionViewModel(params) {
     };
 
     self.save = function() {
-        var notes = PersistenceService.findFirstBy(NotesSection, 'encounterId', self.encounterId());
+        var key = CharacterManager.activeCharacter().key();
+        var notes = PersistenceService.findByPredicates(NotesSection, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key),
+        ])[0];
         if (notes) {
             notes.notes(self.notes());
             notes.visible(self.visible());
@@ -63,14 +72,22 @@ export function NotesSectionViewModel(params) {
     };
 
     self.delete = function() {
-        var notes = PersistenceService.findFirstBy(NotesSection, 'encounterId', self.encounterId());
+        var key = CharacterManager.activeCharacter().key();
+        var notes = PersistenceService.findByPredicates(NotesSection, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key),
+        ])[0];
         notes.delete();
     };
 
     /* Private Methods */
 
     self._dataHasChanged = function() {
-        var notesSection = PersistenceService.findFirstBy(NotesSection, 'encounterId', self.encounterId());
+        var key = CharacterManager.activeCharacter().key();
+        var notesSection = PersistenceService.findByPredicates(NotesSection, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key),
+        ])[0];
         if (!notesSection) {
             notesSection = new NotesSection();
             notesSection.characterId(CharacterManager.activeCharacter().key());

--- a/src/charactersheet/viewmodels/dm/encounter_sections/notes_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/notes_section/index.js
@@ -2,9 +2,9 @@ import {
     CharacterManager,
     Notifications
 } from 'charactersheet/utilities';
+import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';
 import { NotesSection } from 'charactersheet/models';
 import { PersistenceService } from 'charactersheet/services/common/persistence_service';
-import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';
 import ko from 'knockout';
 import sectionIcon from 'images/encounters/quill-ink.svg';
 import template from './index.html';
@@ -43,7 +43,7 @@ export function NotesSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var notes = PersistenceService.findByPredicates(NotesSection, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         if (!notes) {
             notes = new NotesSection();
@@ -61,7 +61,7 @@ export function NotesSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var notes = PersistenceService.findByPredicates(NotesSection, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         if (notes) {
             notes.notes(self.notes());
@@ -75,7 +75,7 @@ export function NotesSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var notes = PersistenceService.findByPredicates(NotesSection, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         notes.delete();
     };
@@ -86,7 +86,7 @@ export function NotesSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var notesSection = PersistenceService.findByPredicates(NotesSection, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         if (!notesSection) {
             notesSection = new NotesSection();

--- a/src/charactersheet/viewmodels/dm/encounter_sections/npc_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/npc_section/index.js
@@ -1,4 +1,3 @@
-import 'bin/knockout-bootstrap-modal';
 import {
     CharacterManager,
     Notifications,
@@ -12,11 +11,12 @@ import {
     PersistenceService,
     SortService
 } from 'charactersheet/services';
-import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';
 import { Fixtures } from 'charactersheet/utilities';
+import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';
 import ko from 'knockout';
 import sectionIcon from 'images/encounters/swordman.svg';
 import template from './index.html';
+
 
 export function NPCSectionViewModel(params) {
     var self = this;
@@ -80,7 +80,7 @@ export function NPCSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var section = PersistenceService.findByPredicates(NPCSection, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         if (!section) {
             section = new NPCSection();
@@ -101,7 +101,7 @@ export function NPCSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var section = PersistenceService.findByPredicates(NPCSection, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         if (section) {
             section.delete();
@@ -203,7 +203,7 @@ export function NPCSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var npc = PersistenceService.findByPredicates(NPC, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         if (npc) {
             self.npcs(npc);
@@ -211,7 +211,7 @@ export function NPCSectionViewModel(params) {
 
         var section = PersistenceService.findByPredicates(NPCSection, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         if (!section) {
             section = new NPCSection();

--- a/src/charactersheet/viewmodels/dm/encounter_sections/npc_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/npc_section/index.js
@@ -204,7 +204,7 @@ export function NPCSectionViewModel(params) {
         var npc = PersistenceService.findByPredicates(NPC, [
             new KeyValuePredicate('encounterId', self.encounterId()),
             new KeyValuePredicate('characterId', key)
-        ])[0];
+        ]);
         if (npc) {
             self.npcs(npc);
         }

--- a/src/charactersheet/viewmodels/dm/encounter_sections/npc_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/npc_section/index.js
@@ -12,6 +12,7 @@ import {
     PersistenceService,
     SortService
 } from 'charactersheet/services';
+import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';
 import { Fixtures } from 'charactersheet/utilities';
 import ko from 'knockout';
 import sectionIcon from 'images/encounters/swordman.svg';
@@ -77,7 +78,10 @@ export function NPCSectionViewModel(params) {
 
     self.save = function() {
         var key = CharacterManager.activeCharacter().key();
-        var section = PersistenceService.findFirstBy(NPCSection, 'encounterId', self.encounterId());
+        var section = PersistenceService.findByPredicates(NPCSection, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key),
+        ])[0];
         if (!section) {
             section = new NPCSection();
             section.encounterId(self.encounterId());
@@ -94,7 +98,11 @@ export function NPCSectionViewModel(params) {
     };
 
     self.delete = function() {
-        var section = PersistenceService.findFirstBy(NPCSection, 'encounterId', self.encounterId());
+        var key = CharacterManager.activeCharacter().key();
+        var section = PersistenceService.findByPredicates(NPCSection, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key),
+        ])[0];
         if (section) {
             section.delete();
         }
@@ -193,12 +201,18 @@ export function NPCSectionViewModel(params) {
 
     self._dataHasChanged = function() {
         var key = CharacterManager.activeCharacter().key();
-        var npc = PersistenceService.findBy(NPC, 'encounterId', self.encounterId());
+        var npc = PersistenceService.findByPredicates(NPC, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key),
+        ])[0];
         if (npc) {
             self.npcs(npc);
         }
 
-        var section = PersistenceService.findFirstBy(NPCSection, 'encounterId', self.encounterId());
+        var section = PersistenceService.findByPredicates(NPCSection, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key),
+        ])[0];
         if (!section) {
             section = new NPCSection();
             section.encounterId(self.encounterId());

--- a/src/charactersheet/viewmodels/dm/encounter_sections/player_text_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/player_text_section/index.js
@@ -87,7 +87,7 @@ export function PlayerTextSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var section = PersistenceService.findByPredicates(PlayerTextSection, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         if (!section) {
             section = new PlayerTextSection();
@@ -108,7 +108,7 @@ export function PlayerTextSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var section = PersistenceService.findByPredicates(PlayerTextSection, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         if (section) {
             section.delete();
@@ -217,7 +217,7 @@ export function PlayerTextSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var playerTexts = PersistenceService.findByPredicates(PlayerText, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ]);
         if (playerTexts) {
             self.playerTexts(playerTexts);
@@ -225,7 +225,7 @@ export function PlayerTextSectionViewModel(params) {
 
         var section = PersistenceService.findByPredicates(PlayerTextSection, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         if (!section) {
             section = new PlayerTextSection();

--- a/src/charactersheet/viewmodels/dm/encounter_sections/player_text_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/player_text_section/index.js
@@ -13,6 +13,7 @@ import {
     PlayerText,
     PlayerTextSection
 } from 'charactersheet/models';
+import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';
 import ko from 'knockout';
 import sectionIcon from 'images/encounters/read.svg';
 import template from './index.html';
@@ -84,7 +85,10 @@ export function PlayerTextSectionViewModel(params) {
 
     self.save = function() {
         var key = CharacterManager.activeCharacter().key();
-        var section = PersistenceService.findFirstBy(PlayerTextSection, 'encounterId', self.encounterId());
+        var section = PersistenceService.findByPredicates(PlayerTextSection, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key),
+        ])[0];
         if (!section) {
             section = new PlayerTextSection();
             section.encounterId(self.encounterId());
@@ -101,7 +105,11 @@ export function PlayerTextSectionViewModel(params) {
     };
 
     self.delete = function() {
-        var section = PersistenceService.findFirstBy(PlayerTextSection, 'encounterId', self.encounterId());
+        var key = CharacterManager.activeCharacter().key();
+        var section = PersistenceService.findByPredicates(PlayerTextSection, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key),
+        ])[0];
         if (section) {
             section.delete();
         }
@@ -207,12 +215,18 @@ export function PlayerTextSectionViewModel(params) {
 
     self._dataHasChanged = function() {
         var key = CharacterManager.activeCharacter().key();
-        var playerTexts = PersistenceService.findBy(PlayerText, 'encounterId', self.encounterId());
+        var playerTexts = PersistenceService.findByPredicates(PlayerText, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key),
+        ]);
         if (playerTexts) {
             self.playerTexts(playerTexts);
         }
 
-        var section = PersistenceService.findFirstBy(PlayerTextSection, 'encounterId', self.encounterId());
+        var section = PersistenceService.findByPredicates(PlayerTextSection, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key),
+        ])[0];
         if (!section) {
             section = new PlayerTextSection();
             section.encounterId(self.encounterId());

--- a/src/charactersheet/viewmodels/dm/encounter_sections/point_of_interest_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/point_of_interest_section/index.js
@@ -12,6 +12,7 @@ import {
     PointOfInterest,
     PointOfInterestSection
 } from 'charactersheet/models/dm';
+import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';
 import ko from 'knockout';
 import sectionIcon from 'images/encounters/rune-stone.svg';
 import template from './index.html';
@@ -69,7 +70,10 @@ export function PointOfInterestSectionViewModel(params) {
 
     self.save = function() {
         var key = CharacterManager.activeCharacter().key();
-        var section = PersistenceService.findFirstBy(PointOfInterestSection, 'encounterId', self.encounterId());
+        var section = PersistenceService.findByPredicates(PointOfInterestSection, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key),
+        ])[0];
         if (!section) {
             section = new PointOfInterestSection();
             section.encounterId(self.encounterId());
@@ -86,7 +90,11 @@ export function PointOfInterestSectionViewModel(params) {
     };
 
     self.delete = function() {
-        var section = PersistenceService.findFirstBy(PointOfInterestSection, 'encounterId', self.encounterId());
+        var key = CharacterManager.activeCharacter().key();
+        var section = PersistenceService.findByPredicates(PointOfInterestSection, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key),
+        ])[0];
         if (section) {
             section.delete();
         }
@@ -176,12 +184,18 @@ export function PointOfInterestSectionViewModel(params) {
 
     self._dataHasChanged = function() {
         var key = CharacterManager.activeCharacter().key();
-        var poi = PersistenceService.findBy(PointOfInterest, 'encounterId', self.encounterId());
+        var poi = PersistenceService.findByPredicates(PointOfInterest, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key),
+        ]);
         if (poi) {
             self.pointsOfInterest(poi);
         }
 
-        var section = PersistenceService.findFirstBy(PointOfInterestSection, 'encounterId', self.encounterId());
+        var section = PersistenceService.findByPredicates(PointOfInterestSection, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key),
+        ])[0];
         if (!section) {
             section = new PointOfInterestSection();
             section.encounterId(self.encounterId());

--- a/src/charactersheet/viewmodels/dm/encounter_sections/point_of_interest_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/point_of_interest_section/index.js
@@ -72,7 +72,7 @@ export function PointOfInterestSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var section = PersistenceService.findByPredicates(PointOfInterestSection, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         if (!section) {
             section = new PointOfInterestSection();
@@ -93,7 +93,7 @@ export function PointOfInterestSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var section = PersistenceService.findByPredicates(PointOfInterestSection, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         if (section) {
             section.delete();
@@ -186,7 +186,7 @@ export function PointOfInterestSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var poi = PersistenceService.findByPredicates(PointOfInterest, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ]);
         if (poi) {
             self.pointsOfInterest(poi);
@@ -194,7 +194,7 @@ export function PointOfInterestSectionViewModel(params) {
 
         var section = PersistenceService.findByPredicates(PointOfInterestSection, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         if (!section) {
             section = new PointOfInterestSection();

--- a/src/charactersheet/viewmodels/dm/encounter_sections/treasure_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/treasure_section/index.js
@@ -16,6 +16,7 @@ import {
     PersistenceService,
     SortService
 } from 'charactersheet/services';
+import { KeyValuePredicate } from 'charactersheet/services/common/persistence_service_components/persistence_service_predicates';
 
 import breastplate from 'images/misc_icons/breastplate.svg';
 import broadsword from 'images/misc_icons/broadsword.svg';
@@ -115,7 +116,10 @@ export function TreasureSectionViewModel(params) {
 
     self.save = function() {
         var key = CharacterManager.activeCharacter().key();
-        var section = PersistenceService.findFirstBy(TreasureSection, 'encounterId', self.encounterId());
+        var section = PersistenceService.findByPredicates(TreasureSection, [
+            new KeyValuePredicate('encounterId', cell.encounterId()),
+            new KeyValuePredicate('characterId', key),
+        ])[0];
         if (!section) {
             section = new TreasureSection();
             section.encounterId(self.encounterId());
@@ -132,7 +136,11 @@ export function TreasureSectionViewModel(params) {
     };
 
     self.delete = function() {
-        var section = PersistenceService.findFirstBy(TreasureSection, 'encounterId', self.encounterId());
+        var key = CharacterManager.activeCharacter().key();
+        var section = PersistenceService.findByPredicates(TreasureSection, [
+            new KeyValuePredicate('encounterId', cell.encounterId()),
+            new KeyValuePredicate('characterId', key),
+        ])[0];
         if (section) {
             section.delete();
         }
@@ -322,12 +330,19 @@ export function TreasureSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var treasure = [];
         self.treasureTypes.forEach(function(type, idx, _){
-            var result = PersistenceService.findBy(type, 'encounterId', self.encounterId());
+            var result = PersistenceService.findByPredicates(type, [
+                new KeyValuePredicate('encounterId', self.encounterId()),
+                new KeyValuePredicate('characterId', key),
+            ]);
             treasure = treasure.concat(result);
         });
         self.treasure(treasure);
 
-        var section = PersistenceService.findFirstBy(TreasureSection, 'encounterId', self.encounterId());
+        var key = CharacterManager.activeCharacter().key();
+        var section = PersistenceService.findByPredicates(TreasureSection, [
+            new KeyValuePredicate('encounterId', self.encounterId()),
+            new KeyValuePredicate('characterId', key),
+        ])[0];
         if (!section) {
             section = new TreasureSection();
             section.encounterId(self.encounterId());

--- a/src/charactersheet/viewmodels/dm/encounter_sections/treasure_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/treasure_section/index.js
@@ -118,7 +118,7 @@ export function TreasureSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var section = PersistenceService.findByPredicates(TreasureSection, [
             new KeyValuePredicate('encounterId', cell.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         if (!section) {
             section = new TreasureSection();
@@ -139,7 +139,7 @@ export function TreasureSectionViewModel(params) {
         var key = CharacterManager.activeCharacter().key();
         var section = PersistenceService.findByPredicates(TreasureSection, [
             new KeyValuePredicate('encounterId', cell.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         if (section) {
             section.delete();
@@ -332,16 +332,15 @@ export function TreasureSectionViewModel(params) {
         self.treasureTypes.forEach(function(type, idx, _){
             var result = PersistenceService.findByPredicates(type, [
                 new KeyValuePredicate('encounterId', self.encounterId()),
-                new KeyValuePredicate('characterId', key),
+                new KeyValuePredicate('characterId', key)
             ]);
             treasure = treasure.concat(result);
         });
         self.treasure(treasure);
 
-        var key = CharacterManager.activeCharacter().key();
         var section = PersistenceService.findByPredicates(TreasureSection, [
             new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key),
+            new KeyValuePredicate('characterId', key)
         ])[0];
         if (!section) {
             section = new TreasureSection();


### PR DESCRIPTION
### Summary of Changes

- An issue with Knockout Computed Observables caused too many mutations of the existing encounter which mapped the data improperly.
- Fixes an issue where multiple campaigns with the same encounters would conflict.

### Issues Fixed

Fixes #1589 

### Changes Proposed (if any)

None

### Screen Shot of Proposed Changes (if UI related)

None