### PR TITLE
Adds Migration to remove duplicate monster ability scores.

### DIFF
--- a/src/charactersheet/migrations/152_1_monster_ability_score.js
+++ b/src/charactersheet/migrations/152_1_monster_ability_score.js
@@ -1,0 +1,52 @@
+import { PersistenceService } from 'charactersheet/services/common/persistence_service';
+
+
+const SCORE_TABLE_NAME = 'MonsterAbilityScore';
+
+
+/**
+ * Generate a unique hash for any unique ability score. This allows comparison
+ * between identical scores in a given monster and encounter.
+ */
+const hashAbilityScore = (score) => {
+    return `${score.characterId}_${score.monsterId}_${score.encounterId}_${score.name}_${score.value}`;
+};
+
+const getUniqueScores = (scores) => {
+    const scoresAndHashes = scores.map((score, i, _) => {
+        return [score.data, hashAbilityScore(score.data)];
+    });
+
+    var uniqueScores = [];
+    var uniqueHashes = [];
+    for (var i=0; i<scoresAndHashes.length; i++) {
+        const [score, hash] = scoresAndHashes[i];
+        if (uniqueHashes.indexOf(hash) === -1) {
+            uniqueHashes.push(hash);
+            uniqueScores.push(score);
+        }
+    }
+    return uniqueScores;
+};
+
+
+/**
+ * Remove redundant monster ability scores from the encounters.
+ */
+export var migration_152_1_monster_ability_scores = {
+    name: 'Remove redundant monster ability scores.',
+    version: '1.5.2',
+    migration: () => {
+        const scores = PersistenceService.findAllObjs(SCORE_TABLE_NAME);
+        const uniqueScores = getUniqueScores(scores);
+
+        // Dump all scores.
+        PersistenceService.drop(SCORE_TABLE_NAME);
+
+        // Add unique scores back.
+        for (var i=0; i<uniqueScores.length; i++) {
+            const score = uniqueScores[i];
+            PersistenceService._saveObj(SCORE_TABLE_NAME, i, score)
+        }
+    }
+};

--- a/src/charactersheet/migrations/152_1_monster_ability_score.js
+++ b/src/charactersheet/migrations/152_1_monster_ability_score.js
@@ -7,19 +7,22 @@ const SCORE_TABLE_NAME = 'MonsterAbilityScore';
 /**
  * Generate a unique hash for any unique ability score. This allows comparison
  * between identical scores in a given monster and encounter.
+ *
+ * Note: The table is parsed in reverse to account for newer records
+ * (the one's we want) being inserted later in the table.
  */
 const hashAbilityScore = (score) => {
-    return `${score.characterId}_${score.monsterId}_${score.encounterId}_${score.name}_${score.value}`;
+    return `${score.characterId}_${score.monsterId}_${score.encounterId}_${score.name}`;
 };
 
-const getUniqueScores = (scores) => {
+export const getUniqueScores = (scores) => {
     const scoresAndHashes = scores.map((score, i, _) => {
         return [score.data, hashAbilityScore(score.data)];
     });
 
     var uniqueScores = [];
     var uniqueHashes = [];
-    for (var i=0; i<scoresAndHashes.length; i++) {
+    for (var i=scoresAndHashes.length-1; i>=0; i--) {
         const [score, hash] = scoresAndHashes[i];
         if (uniqueHashes.indexOf(hash) === -1) {
             uniqueHashes.push(hash);
@@ -46,7 +49,7 @@ export var migration_152_1_monster_ability_scores = {
         // Add unique scores back.
         for (var i=0; i<uniqueScores.length; i++) {
             const score = uniqueScores[i];
-            PersistenceService._saveObj(SCORE_TABLE_NAME, i, score)
+            PersistenceService._saveObj(SCORE_TABLE_NAME, i, score);
         }
     }
 };

--- a/src/charactersheet/migrations/index.js
+++ b/src/charactersheet/migrations/index.js
@@ -5,4 +5,5 @@ export { migration_120_1_weapons } from './120_1_weapons.js';
 export { migration_130_1_armors } from './130_1_armor.js';
 export { migration_130_2_feats_features_proficiencies_daily_features } from './130_2_feats_features_proficiencies_daily_features.js';
 export { migration_150_1_dm_notes } from './150_1_dm_notes.js';
+export { migration_152_1_monster_ability_scores } from './152_1_monster_ability_score.js';
 

--- a/src/charactersheet/utilities/migrations.js
+++ b/src/charactersheet/utilities/migrations.js
@@ -5,7 +5,8 @@ import {
     migration_120_1_weapons,
     migration_130_1_armors,
     migration_130_2_feats_features_proficiencies_daily_features,
-    migration_150_1_dm_notes
+    migration_150_1_dm_notes,
+    migration_152_1_monster_ability_scores
 } from 'charactersheet/migrations';
 
 export var Migrations = {
@@ -21,6 +22,8 @@ export var Migrations = {
         migration_130_1_armors,
         migration_130_2_feats_features_proficiencies_daily_features,
         // v1.5
-        migration_150_1_dm_notes
+        migration_150_1_dm_notes,
+        // v1.5.2
+        migration_152_1_monster_ability_scores
     ]
 };

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -336,3 +336,91 @@ export const dailyFeaturesFixture = [
         }
     }
 ];
+
+
+export const scoresFixture = [
+    {
+        'id': 0,
+        'data': {
+            'characterId':'06f0566c-56c0-44f2-94ea-a56e45ef92d7',
+            'encounterId':'0790ce6f-1bf7-4f03-9196-565a98db86d9',
+            'monsterId':'df0596f4-02b0-4d71-b336-ef5a3e8aacd3',
+            'name':'strength',
+            'value':19
+        }
+    },
+    {
+        'id': 1,
+        'data': {
+            'characterId':'06f0566c-56c0-44f2-94ea-a56e45ef92d7',
+            'encounterId':'0790ce6f-1bf7-4f03-9196-565a98db86d9',
+            'monsterId':'df0596f4-02b0-4d71-b336-ef5a3e8aacd3',
+            'name':'dexterity',
+            'value':10
+        }
+    },
+    // Repeat of 0
+    {
+        'id': 2,
+        'data': {
+            'characterId':'06f0566c-56c0-44f2-94ea-a56e45ef92d7',
+            'encounterId':'0790ce6f-1bf7-4f03-9196-565a98db86d9',
+            'monsterId':'df0596f4-02b0-4d71-b336-ef5a3e8aacd3',
+            'name':'strength',
+            'value':19
+        }
+    },
+    // Repeat of 1
+    {
+        'id': 3,
+        'data': {
+            'characterId':'06f0566c-56c0-44f2-94ea-a56e45ef92d7',
+            'encounterId':'0790ce6f-1bf7-4f03-9196-565a98db86d9',
+            'monsterId':'df0596f4-02b0-4d71-b336-ef5a3e8aacd3',
+            'name':'dexterity',
+            'value':10
+        }
+    },
+    // Repeat of 0
+    {
+        'id': 4,
+        'data': {
+            'characterId':'06f0566c-56c0-44f2-94ea-a56e45ef92d7',
+            'encounterId':'0790ce6f-1bf7-4f03-9196-565a98db86d9',
+            'monsterId':'df0596f4-02b0-4d71-b336-ef5a3e8aacd3',
+            'name':'strength',
+            'value':19
+        }
+    },
+    {
+        'id': 6,
+        'data': {
+            'characterId':'5555555-56c0-44f2-94ea-a56e45ef92d7',
+            'encounterId':'0790ce6f-1bf7-4f03-9196-565a98db86d9',
+            'monsterId':'df0596f4-02b0-4d71-b336-ef5a3e8aacd3',
+            'name':'dexterity',
+            'value':10
+        }
+    },
+    {
+        'id': 7,
+        'data': {
+            'characterId':'5555555-56c0-44f2-94ea-a56e45ef92d7',
+            'encounterId':'0790ce6f-1bf7-4f03-9196-565a98db86d9',
+            'monsterId':'df0596f4-02b0-4d71-b336-ef5a3e8aacd3',
+            'name':'strength',
+            'value':19
+        }
+    },
+    // Repeat of 6
+    {
+        'id': 8,
+        'data': {
+            'characterId':'5555555-56c0-44f2-94ea-a56e45ef92d7',
+            'encounterId':'0790ce6f-1bf7-4f03-9196-565a98db86d9',
+            'monsterId':'df0596f4-02b0-4d71-b336-ef5a3e8aacd3',
+            'name':'dexterity',
+            'value':10
+        }
+    }
+];

--- a/test/migrations/index.js
+++ b/test/migrations/index.js
@@ -3,3 +3,4 @@ import './test_migration_110_2_spells';
 import './test_migration_110_3_stats';
 import './test_migration_120_1_weapons';
 import './test_migration_130_2_feats_features_proficiencies_daily_features';
+import './test_migration_152_1_monster_ability_score';

--- a/test/migrations/test_migration_152_1_monster_ability_score.js
+++ b/test/migrations/test_migration_152_1_monster_ability_score.js
@@ -1,0 +1,17 @@
+import { getUniqueScores, migration_152_1_monster_ability_scores } from 'charactersheet/migrations/152_1_monster_ability_score';
+import { PersistenceService } from 'charactersheet/services/common/persistence_service';
+import Should from 'should';
+import { scoresFixture } from '../fixtures';
+import simple from 'simple-mock';
+
+
+describe('152 Monster Ability Score', () => {
+    describe('Get Unique Hashes', () => {
+        it('should return a list of scores that are unique', () => {
+            const scores = scoresFixture;
+            uniqueScores.length.should.equal(9);
+            const uniqueScores = getUniqueScores(scores);
+            uniqueScores.length.should.equal(4);
+        });
+    });
+});

--- a/test/migrations/test_migration_152_1_monster_ability_score.js
+++ b/test/migrations/test_migration_152_1_monster_ability_score.js
@@ -9,7 +9,7 @@ describe('152 Monster Ability Score', () => {
     describe('Get Unique Hashes', () => {
         it('should return a list of scores that are unique', () => {
             const scores = scoresFixture;
-            uniqueScores.length.should.equal(9);
+            scores.length.should.equal(8);
             const uniqueScores = getUniqueScores(scores);
             uniqueScores.length.should.equal(4);
         });


### PR DESCRIPTION
### Summary of Changes

- Adds migration to remove old and unneeded ability scores generated by broken code.
- Adds tests.

### Issues Fixed

Fixes #1552 
Related #1640 

### Changes Proposed (if any)

None

### Screen Shot of Proposed Changes (if UI related)

None