### PR TITLE
Saving encounter with notes doesn't save a notes encounter section

### DIFF
--- a/src/charactersheet/viewmodels/dm/encounter/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter/index.js
@@ -90,7 +90,6 @@ export function EncounterViewModel() {
         });
         sections([]);
         self.addEncounterToList(encounter());
-        Notifications.encounters.changed.dispatch();
     };
 
     /* Manage Encounter Methods */

--- a/src/charactersheet/viewmodels/dm/encounter_sections/notes_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/notes_section/index.js
@@ -14,7 +14,7 @@ export function NotesSectionViewModel(params) {
 
     self.sectionIcon = sectionIcon;
     self.notes = ko.observable('');
-    self.visible = ko.observable(false);
+    self.visible = ko.observable();
 
     self.encounter = params.encounter;
     self.encounterId = ko.pureComputed(function() {


### PR DESCRIPTION
### Summary of Changes

Removes an excessive notification that forces encounter sections to update.

### Issues Fixed

None

### Changes Proposed (if any)

None

### Screen Shot of Proposed Changes (if UI related)

None
