### PR TITLE
Deleting a character no longer forces switch to first + UI tweaks.

### DIFF
--- a/src/charactersheet/viewmodels/common/characters/index.html
+++ b/src/charactersheet/viewmodels/common/characters/index.html
@@ -15,7 +15,7 @@
       <div class="modal-body">
         <div class='container-fluid'>
           <table data-bind='foreach: characters' class="table table-hover table-ac-bordered">
-            <tr>
+            <tr data-bind="css: $parent.playerSelectedCSS($data)">
               <td class="clickable"
                 data-bind="click: $parent.changeCharacter"
                 data-dismiss="modal">

--- a/src/charactersheet/viewmodels/common/characters/index.js
+++ b/src/charactersheet/viewmodels/common/characters/index.js
@@ -27,6 +27,19 @@ export function CharactersViewModel(params) {
         self._updatedSelectedCharacter();
     };
 
+    self.changeCharacter = (character) => {
+        // Don't switch to the same character.
+        var activeCharacterKey = null;
+        if (CharacterManager.activeCharacter()) {
+            activeCharacterKey = CharacterManager.activeCharacter().key();
+        }
+
+        // Do switch
+        if (character.key() !== activeCharacterKey) {
+            CharacterManager.changeCharacter(character.key());
+        }
+    };
+
     self.addCharacter = () => {
         var character = new Character();
         character.key(uuid.v4());

--- a/src/charactersheet/viewmodels/common/characters/index.js
+++ b/src/charactersheet/viewmodels/common/characters/index.js
@@ -17,26 +17,17 @@ export function CharactersViewModel(params) {
     self.characters = ko.observableArray([]);
     self.componentStatus = params.modalStatus || ko.observable(false);
     self.modalStatus = ko.observable(false);
+    self.selectedCharacter = ko.observable();
 
-    self.load = function() {
+    self.load = () => {
         self.characters(PersistenceService.findAll(Character));
         self.modalStatus(self.componentStatus());
+
+        Notifications.characterManager.changed.add(self._updatedSelectedCharacter);
+        self._updatedSelectedCharacter();
     };
 
-    self.changeCharacter = function(character) {
-        // Don't switch to the same character.
-        var activeCharacterKey = null;
-        if (CharacterManager.activeCharacter()) {
-            activeCharacterKey = CharacterManager.activeCharacter().key();
-        }
-
-        // Do switch
-        if (character.key() !== activeCharacterKey) {
-            CharacterManager.changeCharacter(character.key());
-        }
-    };
-
-    self.addCharacter = function() {
+    self.addCharacter = () => {
         var character = new Character();
         character.key(uuid.v4());
         character.playerType(PlayerTypes.characterPlayerType);
@@ -50,31 +41,52 @@ export function CharactersViewModel(params) {
         window.location = character.url();
     };
 
-    self.removeCharacter = function(character) {
+    self.removeCharacter = (character) => {
+        const deletedCharacterIndex = self.characters().indexOf(character);
+
         //Remove the character.
         character.delete();
         self.characters.remove(character);
 
         if (self.characters().length === 0) {
             self.modalStatus(false);
-        } else {
-            // Change to the first character in the list
-            CharacterManager.changeCharacter(self.characters()[0].key());
+        } else if (character.key() === CharacterManager.activeCharacter().key()) {
+            // If we've deleted the current character...
+            // switch to the same index position bounded by list length.
+            const index = (
+                deletedCharacterIndex < self.characters().length ?
+                deletedCharacterIndex :
+                self.characters().length - 1
+            );
+            CharacterManager.changeCharacter(self.characters()[index].key());
         }
     };
 
-    self.modalFinishedClosing = function() {
+    self.modalFinishedClosing = () => {
         if (self.characters().length === 0) {
             Notifications.characters.allRemoved.dispatch();
         }
         self.componentStatus(false);
     };
 
-    self.localStoragePercent = ko.computed(function() {
-        var n = self.characters().lenth; //Force ko to recompute on change.
+    self.playerSelectedCSS = (character) => {
+        if (character.key() === self.selectedCharacter().key()) {
+            return 'active';
+        }
+        return '';
+    };
+
+    self.localStoragePercent = ko.computed(() => {
+        self.characters(); //Force ko to recompute on change.
         var used = JSON.stringify(localStorage).length / (0.5 * 1024 * 1024);
         return (used / self.totalLocalStorage * 100).toFixed(2);
     });
+
+    // Private Methods
+
+    self._updatedSelectedCharacter = () => {
+        self.selectedCharacter(CharacterManager.activeCharacter());
+    };
 }
 
 ko.components.register('characters', {


### PR DESCRIPTION
### Summary of Changes

- Deleting a character no longer causes a switch to the first character in the list, instead does not change the character unless the active one is being deleted. In this case it switches to the character at the same index post-delete (bounded by the total number of characters).
- Character switcher now also shows which character is selected using active CSS.

### Issues Fixed

Fixes #1553 

### Changes Proposed (if any)

None

### Screen Shot of Proposed Changes (if UI related)

![screenshot 2017-12-26 16 04 04](https://user-images.githubusercontent.com/3310280/34366834-68be80ba-ea56-11e7-92f2-0a8c99fb5996.png)
