### PR TITLE
Fixes player/campaign image padding

### DIFF
--- a/src/charactersheet/viewmodels/common/root/index.html
+++ b/src/charactersheet/viewmodels/common/root/index.html
@@ -91,7 +91,7 @@
 <!-- ko if: shouldShowApp -->
 <div class="container-fluid main">
   <div class="col-lg-10 col-xs-12 col-lg-offset-1">
-  <div id="characters" class="container-fluid">
+  <div id="characters" class="container-fluid characters-module-style">
     <div class="row">
       <div class="col-sm-12">
         <div class="row">


### PR DESCRIPTION
### Summary of Changes

Adds padding back to player picture so that the inspiration doesn't look cut off at the top.

### Issues Fixed

Fixes #1700

### Screen Shot of Proposed Changes (if UI related)

![image](https://user-images.githubusercontent.com/7286387/34464673-75d5df04-ee3f-11e7-9c34-0c9213bb3dd1.png)

