### PR TITLE
Fixes issue with editing monsters.

### DIFF
--- a/src/charactersheet/viewmodels/dm/encounter_sections/monster_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/monster_section/index.js
@@ -162,13 +162,14 @@ export function MonsterSectionViewModel(params) {
 
     self.editMonster = function(monster) {
         self.editItemIndex = monster.__id;
-        self.currentEditItem(new Monster());
-        self.currentEditItem().importValues(monster.exportValues());
-        self.currentEditItem().abilityScores(monster.abilityScores().map(function(e, i, _) {
+        var editMonster = new Monster();
+        editMonster.importValues(monster.exportValues());
+        editMonster.abilityScores(monster.abilityScores().map(function(e, i, _) {
             var abilityScore = new MonsterAbilityScore();
             abilityScore.importValues(e);
             return abilityScore;
         }));
+        self.currentEditItem(editMonster);
         self.openEditModal(true);
     };
 


### PR DESCRIPTION
### Summary of Changes

- Monster-to-edit was being bound to the view before it had a value for it's ability-scores. Moved the binding to later after scores have been set.
- This worked before because it was importing the values of the old, repeated scores by default. When we fixed that bug, it caused this.

### Issues Fixed

Fixes #1713 

### Changes Proposed (if any)

- We might want to think about intializing a monster's ability scores to have default values: str, cha, int, etc be default then just override the values. Right now, monsters are created with 6 scores, but they're all just useless. They have no name or type.

### Screen Shot of Proposed Changes (if UI related)

None

  