### PR TITLE
Update damage bar to use a damageHandler

### DIFF
--- a/src/charactersheet/models/character/health.js
+++ b/src/charactersheet/models/character/health.js
@@ -20,8 +20,7 @@ export function Health() {
     self.damage = ko.observable(0);
 
     self.hitpoints = ko.pureComputed(function() {
-        var damage = self.damage() ? parseInt(self.damage()) : 0;
-        return self.totalHitpoints() - damage;
+        return parseInt(self.regularHitpointsRemaining()) + parseInt(self.tempHitpointsRemaining());
     }, self);
 
     self.totalHitpoints = ko.pureComputed(function() {
@@ -31,19 +30,14 @@ export function Health() {
     }, self);
 
     self.tempHitpointsRemaining = ko.pureComputed(function() {
-        var damage = self.damage() ? parseInt(self.damage()) : 0;
         var tempHP = self.tempHitpoints() ? parseInt(self.tempHitpoints()) : 0;
-        return tempHP - damage;
+        return tempHP;
     }, self);
 
     self.regularHitpointsRemaining = ko.pureComputed(function() {
-        if (self.tempHitpointsRemaining() > 0) {
-            return parseInt(self.maxHitpoints());
-        }
         var damage = self.damage() ? parseInt(self.damage()) : 0;
-        var tempHP = self.tempHitpoints() ? parseInt(self.tempHitpoints()) : 0;
         var maxHP = self.maxHitpoints() ? parseInt(self.maxHitpoints()) : 0;
-        return maxHP - (damage - tempHP);
+        return maxHP - damage;
     }, self);
 
     //Progress bar methods.

--- a/src/charactersheet/viewmodels/character/stats/index.html
+++ b/src/charactersheet/viewmodels/character/stats/index.html
@@ -36,7 +36,7 @@
                   <span data-bind="text: health().maxHitpoints"></span>
               </td>
               <td>
-                <plus-minus params="value: health().damage,
+                <plus-minus params="value: damageHandler,
                   max: health().totalHitpoints">
                   </plus-minus>
               </td>

--- a/src/charactersheet/viewmodels/character/stats/index.js
+++ b/src/charactersheet/viewmodels/character/stats/index.js
@@ -28,6 +28,32 @@ export function StatsViewModel() {
     self.modalOpen = ko.observable(false);
     self._dummy = ko.observable();
 
+
+    self.damageHandler = ko.computed({
+        read: function() {
+            return self.health().damage();},
+        write: function(value) {
+            if (self.health().tempHitpoints()) {
+                // Find the damage delta, then apply to temp hit points first.
+                var damageChange = value - self.health().damage();
+                if (damageChange > 0) {
+                    var remainingTempHP = self.health().tempHitpoints() - damageChange;
+                    if (remainingTempHP >= 0 ) {
+                        // New damage value did not eliminate temporary hit points
+                        // reduce temporary hit points, and do not apply to damage.
+                        self.health().tempHitpoints(remainingTempHP);
+                        value = self.health().damage();
+                    } else { // remainingTempHP is negative.
+                        self.health().tempHitpoints(0);
+                        value = self.health().damage() + remainingTempHP;
+                    }
+                }
+            }
+            self.health().damage(value);
+        },
+        owner: self
+    });
+
     self.load = function() {
         Notifications.global.save.add(self.save);
 
@@ -167,6 +193,7 @@ export function StatsViewModel() {
     self.resetOnLongRest = function() {
         self.resetHitDice();
         self.health().damage(0);
+        self.health().tempHitpoints(0);
         self.health().save();
         self.damageDataHasChanged();
     };
@@ -240,6 +267,7 @@ export function StatsViewModel() {
     };
 
     /* Utility Methods */
+
 
     self.deathSaveSuccessDataHasChanged = function() {
         self.deathSaveSuccessList().forEach(function(save, idx, _) {

--- a/test/viewmodels/test_stats.js
+++ b/test/viewmodels/test_stats.js
@@ -36,8 +36,8 @@ describe('Stats View Model', function() {
                 var stats = new StatsViewModel();
                 stats.health().maxHitpoints(10);
                 stats.health().tempHitpoints(5);
-                stats.health().damage(0);
-                stats.health().hitpoints().should.equal(15);
+                stats.damageHandler(4);
+                stats.health().hitpoints().should.equal(11);
             });
         });
 
@@ -46,7 +46,7 @@ describe('Stats View Model', function() {
                 var stats = new StatsViewModel();
                 stats.health().maxHitpoints(10);
                 stats.health().tempHitpoints(5);
-                stats.health().damage(4);
+                stats.damageHandler(4);
                 stats.health().tempHitpointsRemaining().should.equal(1);
             });
         });
@@ -57,7 +57,8 @@ describe('Stats View Model', function() {
                 stats.health().maxHitpoints(10);
                 stats.health().tempHitpoints(5);
                 stats.health().damage(8);
-                stats.health().regularHitpointsRemaining().should.equal(7);
+                stats.health().tempHitpointsRemaining().should.equal(5);
+                stats.health().regularHitpointsRemaining().should.equal(2);
             });
         });
 
@@ -66,9 +67,9 @@ describe('Stats View Model', function() {
                 var stats = new StatsViewModel();
                 stats.health().maxHitpoints(10);
                 stats.health().tempHitpoints(5);
-                stats.health().damage(8);
+                stats.damageHandler(8);
                 stats.health().isKnockedOut().should.equal(false);
-                stats.health().damage(15);
+                stats.damageHandler(15);
                 stats.health().isKnockedOut().should.equal(true);
             });
         });
@@ -78,9 +79,9 @@ describe('Stats View Model', function() {
                 var stats = new StatsViewModel();
                 stats.health().maxHitpoints(10);
                 stats.health().tempHitpoints(5);
-                stats.health().damage(8);
+                stats.damageHandler(8);
                 stats.health().isDangerous().should.equal(false);
-                stats.health().damage(14);
+                stats.damageHandler(9);
                 stats.health().isDangerous().should.equal(true);
             });
         });
@@ -90,9 +91,9 @@ describe('Stats View Model', function() {
                 var stats = new StatsViewModel();
                 stats.health().maxHitpoints(10);
                 stats.health().tempHitpoints(5);
-                stats.health().damage(6);
+                stats.damageHandler(6);
                 stats.health().isWarning().should.equal(false);
-                stats.health().damage(8);
+                stats.damageHandler(8);
                 stats.health().isWarning().should.equal(true);
             });
         });
@@ -102,11 +103,11 @@ describe('Stats View Model', function() {
                 var stats = new StatsViewModel();
                 stats.health().maxHitpoints(10);
                 stats.health().tempHitpoints(5);
-                stats.health().damage(6);
+                stats.damageHandler(6);
                 stats.health().progressType().should.equal('progress-bar-success');
-                stats.health().damage(8);
+                stats.damageHandler(7);
                 stats.health().progressType().should.equal('progress-bar-warning');
-                stats.health().damage(11);
+                stats.damageHandler(9);
                 stats.health().progressType().should.equal('progress-bar-danger');
             });
         });
@@ -116,11 +117,11 @@ describe('Stats View Model', function() {
                 var stats = new StatsViewModel();
                 stats.health().maxHitpoints(10);
                 stats.health().tempHitpoints(5);
-                stats.health().damage(13);
+                stats.health().damage(8);
                 var e = stats.health().exportValues();
                 e.maxHitpoints.should.equal(10);
                 e.tempHitpoints.should.equal(5);
-                e.damage.should.equal(13);
+                e.damage.should.equal(8);
             });
         });
 


### PR DESCRIPTION
### Summary of Changes
 - damage plus-minus now uses a damage handler to subtract damage from temporary hit points before changing the stored damage.
 - temporary hit points are reset on long rest.

### Issues Fixed


### Changes Proposed (if any)



### Screen Shot of Proposed Changes (if UI related)


