### PR TITLE
Added ability to filter by currently castable spells.

### DIFF
--- a/src/charactersheet/models/common/spell.js
+++ b/src/charactersheet/models/common/spell.js
@@ -79,6 +79,22 @@ export function Spell() {
         }
     });
 
+    self.spellIsCastable = ko.pureComputed(function() {
+        if (self.spellPrepared() === true || self.spellAlwaysPrepared() === true || self.spellLevel() === 0) {
+            return true;
+        } else {
+            return false;
+        }
+    });
+
+    self.spellTypeLabel = ko.pureComputed(function() {
+        if (self.spellType() === 'Savings Throw') {
+            return ('Savings Throw' + ': ' + self.spellSaveAttr());
+        } else {
+            return self.spellType();
+        }
+    });
+
     self.spellSummaryLabel = ko.pureComputed(function() {
         var header = parseInt(self.spellLevel()) !== 0 ? 'Level ' : '';
         return self.spellSchool() + ', ' + header + self.spellLevelLabel();

--- a/src/charactersheet/viewmodels/character/spells/index.html
+++ b/src/charactersheet/viewmodels/character/spells/index.html
@@ -3,9 +3,9 @@
     <table class="table table-responsive table-ac-bordered table-hover">
       <thead>
         <tr>
-          <th data-bind="click: function(){sortBy('spellPrepared');}">
-            <span class="glyphicon glyphicon-check"></span>
-            <span data-bind="css: sortArrow('spellPrepared')"></span>
+          <th>
+            Castable
+            <input data-bind="checked: filteredByCastable" type="checkbox" href="#"></input>
           </th>
           <th data-bind="click: function(){sortBy('spellName');}">
             Spell
@@ -15,9 +15,9 @@
             Level
             <span data-bind="css: sortArrow('spellLevel')"></span>
           </th>
-          <th class="hidden-sm hidden-xs" data-bind="click: function(){sortBy('spellType');}">
+          <th class="hidden-sm hidden-xs" data-bind="click: function(){sortBy('spellTypeLabel');}">
             Type
-            <span data-bind="css: sortArrow('spellType')"></span>
+            <span data-bind="css: sortArrow('spellTypeLabel')"></span>
           </th>
           <th class="hidden-xs" data-bind="click: function(){sortBy('spellDmg');}">
             Damage
@@ -43,16 +43,20 @@
       <!-- ko foreach: filteredAndSortedSpells -->
         <tr class="clickable">
           <td>
-            <!-- ko if: spellLevel() != 0 -->
-              <input data-bind="checked: spellPrepared || spellAlwaysPrepared,
+            <!-- ko ifnot: spellLevel() == 0  || spellAlwaysPrepared -->
+              <input data-bind="checked: spellPrepared,
                 disable: spellAlwaysPrepared" type="checkbox" href="#"></input>
             <!-- /ko -->
+            <!-- ko if: spellLevel() == 0  || spellAlwaysPrepared -->
+              <input checked disabled type="checkbox" href="#"></input>
+            <!-- /ko -->
+
           </td>
           <td data-bind="text: spellNameLabel, click: $parent.editSpell"
                href="#"></td>
           <td data-bind="text: spellLevelLabel, click: $parent.editSpell"
                href="#"></td>
-          <td class="hidden-sm hidden-xs" data-bind="text: spellType, click: $parent.editSpell"
+          <td class="hidden-sm hidden-xs" data-bind="text: spellTypeLabel, click: $parent.editSpell"
                href="#"></td>
           <td class="hidden-xs" data-bind="text: spellDamageLabel, click: $parent.editSpell"
                href="#"></td>
@@ -68,12 +72,19 @@
           </td>
         </tr>
       <!-- /ko -->
-      <!-- ko if: filteredAndSortedSpells().length == 0 -->
+      <!-- ko if: spellbook().length == 0 -->
         <tr class="clickable">
           <td href="#" data-toggle="modal"
             data-target="#addSpell" colspan="8" class="text-center">
             <i class="fa fa-plus fa-color"></i>
             Add a new spell
+          </td>
+        </tr>
+      <!-- /ko -->
+      <!-- ko if: spellbook().length > 0 && filteredAndSortedSpells().length == 0 -->
+        <tr class="clickable">
+          <td href="#" colspan="8" class="text-center">
+            No Spells are currently castable
           </td>
         </tr>
       <!-- /ko -->

--- a/src/charactersheet/viewmodels/character/spells/index.js
+++ b/src/charactersheet/viewmodels/character/spells/index.js
@@ -19,10 +19,8 @@ export function SpellbookViewModel() {
     self.sorts = {
         'spellName asc': { field: 'spellName', direction: 'asc'},
         'spellName desc': { field: 'spellName', direction: 'desc'},
-        'spellPrepared asc': { field: 'spellPrepared', direction: 'asc', booleanType: true},
-        'spellPrepared desc': { field: 'spellPrepared', direction: 'desc', booleanType: true},
-        'spellType asc': { field: 'spellType', direction: 'asc'},
-        'spellType desc': { field: 'spellType', direction: 'desc'},
+        'spellTypeLabel asc': { field: 'spellTypeLabel', direction: 'asc'},
+        'spellTypeLabel desc': { field: 'spellTypeLabel', direction: 'desc'},
         'spellDmg asc': { field: 'spellDmg', direction: 'asc'},
         'spellDmg desc': { field: 'spellDmg', direction: 'desc'},
         'spellLevel asc': { field: 'spellLevel', direction: 'asc', numeric: true},
@@ -46,6 +44,9 @@ export function SpellbookViewModel() {
     self.spellSchoolIconCSS = ko.observable('');
 
     self.filter = ko.observable('');
+
+    self.filteredByCastable = ko.observable(false);
+
     self.sort = ko.observable(self.sorts['spellName asc']);
 
     self.numberOfPrepared = ko.computed(function(){
@@ -155,7 +156,13 @@ export function SpellbookViewModel() {
      * questions/17387435/javascript-sort-array-of-objects-by-a-boolean-property
      */
     self.filteredAndSortedSpells = ko.computed(function() {
-        return SortService.sortAndFilter(self.spellbook(), self.sort(), null);
+        var spellbook = self.spellbook();
+        if (self.filteredByCastable()) {
+            spellbook = self.spellbook().filter(function(spell) {
+                return spell.spellIsCastable();
+            }, self);
+        }
+        return SortService.sortAndFilter(spellbook, self.sort(), null);
     });
 
     /**

--- a/test/models/test_spell.js
+++ b/test/models/test_spell.js
@@ -127,4 +127,30 @@ describe('Spell Model', function() {
             spell.spellLevelLabel().should.equal(1);
         });
     });
+
+    describe('A Castable Spell', function() {
+        it('should be castable if it is a cantrip', function() {
+            var cantrip = new Spell();
+            cantrip.spellLevel(0);
+            cantrip.spellIsCastable().should.equal(true);
+        });
+        it('should be castable if it is prepared', function() {
+            var spell = new Spell();
+            spell.spellLevel(1);
+            spell.spellPrepared(true);
+            spell.spellIsCastable().should.equal(true);
+        });
+        it('should be castable if it is always prepared', function() {
+            var spell = new Spell();
+            spell.spellLevel(1);
+            spell.spellAlwaysPrepared(true);
+            spell.spellIsCastable().should.equal(true);
+        });
+        it('should not be castable if it is not prepared', function() {
+            var spell = new Spell();
+            spell.spellLevel(1);
+            spell.spellIsCastable().should.equal(false);
+        });
+    });
+
 });

--- a/test/viewmodels/test_spells.js
+++ b/test/viewmodels/test_spells.js
@@ -86,10 +86,6 @@ describe('SpellsViewModel', function(){
             book.sort().should.equal(book.sorts['spellName desc']);
             book.sortBy('spellName');
             book.sort().should.equal(book.sorts['spellName asc']);
-            book.sortBy('spellPrepared');
-            book.sort().should.equal(book.sorts['spellPrepared asc']);
-            book.sortBy('spellPrepared');
-            book.sort().should.equal(book.sorts['spellPrepared desc']);
             book.sortBy('spellLevel');
             book.sort().should.equal(book.sorts['spellLevel asc']);
             book.sortBy('spellLevel');
@@ -97,15 +93,28 @@ describe('SpellsViewModel', function(){
         });
     });
 
+    describe('filteredAndSortedSpells', function() {
+        it('should display only spellIsCastable spells when filtered', function() {
+            var book = new SpellbookViewModel();
+            var spell = new Spell();
+            spell.spellLevel(1);
+            var spell2 = new Spell();
+            spell2.spellLevel(1);
+            spell2.spellPrepared(true);
+            book.spellbook([spell, spell2]);
+            book.filteredAndSortedSpells().length.should.equal(2);
+            book.filteredByCastable(true);
+            book.filteredAndSortedSpells().length.should.equal(1);
+        });
+    });
+
+
     describe('Sort Arrow', function() {
         it('should sort the list of skills by given criteria', function() {
             var book = new SpellbookViewModel();
             book.sortBy('spellName');
             book.sort().should.equal(book.sorts['spellName desc']);
             book.sortArrow('spellName').should.equal('fa fa-arrow-down fa-color');
-            book.sortBy('spellPrepared');
-            book.sort().should.equal(book.sorts['spellPrepared asc']);
-            book.sortArrow('spellPrepared').should.equal('fa fa-arrow-up fa-color');
             book.sortArrow('spellLevel').should.equal('');
             book.sortBy('spellName');
             book.sort().should.equal(book.sorts['spellName asc']);


### PR DESCRIPTION
### Summary of Changes

 These are spells that are a) cantrips, b) prepared, c) always prepared. Updated displayed checkbox to display castable spells. Added save attribute to listing when the type of spell is saving throw.

### Issues Fixed



### Changes Proposed (if any)
Ability, especially for wizards, clerics, druids, and paladins, to filter out un-memorized entries during play.

### Screen Shot of Proposed Changes (if UI related)
![castable_spells](https://user-images.githubusercontent.com/1039347/34756029-c87e9158-f57c-11e7-884a-85a1deaa5bb3.gif)

