### PR TITLE
Environment is created when loaded if none for the given encounter exist

### DIFF
--- a/src/charactersheet/viewmodels/dm/encounter_sections/environment_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/environment_section/index.js
@@ -89,19 +89,6 @@ export function EnvironmentSectionViewModel(params) {
 
         self._connectionHasChanged();
 
-        // Search for the current environment and if it doesn't exist, then create.
-        var key = CharacterManager.activeCharacter().key();
-        var environment = PersistenceService.findByPredicates(Environment, [
-            new KeyValuePredicate('encounterId', self.encounterId()),
-            new KeyValuePredicate('characterId', key)
-        ])[0];
-        if (!environment) {
-            environment = new Environment();
-            environment.characterId(key);
-            environment.encounterId(self.encounterId());
-            environment.save();
-        }
-
         self.encounter.subscribe(function() {
             self._dataHasChanged();
         });
@@ -109,12 +96,15 @@ export function EnvironmentSectionViewModel(params) {
     };
 
     self.save = function() {
+        console.log('SAVING ENV')
         var key = CharacterManager.activeCharacter().key();
         var environment = PersistenceService.findByPredicates(Environment, [
             new KeyValuePredicate('encounterId', self.encounterId()),
             new KeyValuePredicate('characterId', key)
         ])[0];
+        console.log(environment)
         if (environment) {
+            console.log('SAVING ENV -- DATA')
             environment.imageUrl(self.imageUrl());
             environment.weather(self.weather());
             environment.terrain(self.terrain());
@@ -198,6 +188,7 @@ export function EnvironmentSectionViewModel(params) {
             self.tagline(environmentSection.tagline());
         }
 
+        // Search for the current environment and if it doesn't exist, then create.
         var environment = PersistenceService.findByPredicates(Environment, [
             new KeyValuePredicate('encounterId', self.encounterId()),
             new KeyValuePredicate('characterId', key)
@@ -210,6 +201,11 @@ export function EnvironmentSectionViewModel(params) {
             self.description(environment.description());
             self.isExhibited(environment.isExhibited());
         } else {
+            environment = new Environment();
+            environment.characterId(key);
+            environment.encounterId(self.encounterId());
+            environment.save();
+
             self.clearFields();
         }
 

--- a/src/charactersheet/viewmodels/dm/encounter_sections/environment_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/environment_section/index.js
@@ -96,15 +96,12 @@ export function EnvironmentSectionViewModel(params) {
     };
 
     self.save = function() {
-        console.log('SAVING ENV')
         var key = CharacterManager.activeCharacter().key();
         var environment = PersistenceService.findByPredicates(Environment, [
             new KeyValuePredicate('encounterId', self.encounterId()),
             new KeyValuePredicate('characterId', key)
         ])[0];
-        console.log(environment)
         if (environment) {
-            console.log('SAVING ENV -- DATA')
             environment.imageUrl(self.imageUrl());
             environment.weather(self.weather());
             environment.terrain(self.terrain());


### PR DESCRIPTION
### Summary of Changes

- Environment were only created if non-existent at component load. This is inaccurate. Now whenever the backing encounter changes, there is the opportunity to create a new environment if it doesnt exist.

### Issues Fixed

Fixes #1725 
