### PR TITLE
Changes Ejabberd URL to be on a standard port

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -42,7 +42,7 @@ module.exports = merge(common, {
             /**
              * The connection URL for the XMPP service.
              */
-            'XMPP_WS_URL': JSON.stringify('wss://adventurerscodex.com:5280/websocket/'),
+            'XMPP_WS_URL': JSON.stringify('wss://adventurerscodex.com/chat/'),
             /**
              * Date and time the build was created
              */

--- a/webpack.test.js
+++ b/webpack.test.js
@@ -42,7 +42,7 @@ module.exports = merge(common, {
             /**
              * The connection URL for the XMPP service.
              */
-            'XMPP_WS_URL': JSON.stringify('wss://nightly.adventurerscodex.com:5280/websocket/'),
+            'XMPP_WS_URL': JSON.stringify('wss://nightly.adventurerscodex.com/chat/'),
             /**
              * Date and time the build was created
              */


### PR DESCRIPTION
### Summary of Changes

- See other related changes here: https://github.com/adventurerscodex/configuration/pull/30
- XMPP now occurs over a web socket connection on a standard HTTP port under `/chat/` in both `nightly` and `prod`. This should help with connection issues caused by adblockers, VPNs and strict browser privacy settings.

### Issues Fixed

None logged.