### PR TITLE
Autocomplete fix

### DIFF
--- a/src/charactersheet/utilities/fixtures.js
+++ b/src/charactersheet/utilities/fixtures.js
@@ -314,7 +314,6 @@ export var Fixtures = {
     },
     weapon: {
         weaponDamageTypeOptions: [
-            '',
             'Acid',
             'Bludgeoning',
             'Cold',
@@ -339,7 +338,6 @@ export var Fixtures = {
             'Simple'
         ],
         weaponPropertyOptions: [
-            '',
             'Ammunition',
             'Ammunition and Heavy',
             'Ammunition and Loading',

--- a/src/charactersheet/viewmodels/character/armor/index.html
+++ b/src/charactersheet/viewmodels/character/armor/index.html
@@ -97,7 +97,7 @@
                          id="armorAddNameInput"
                          placeholder="Chain Mail"
                          data-bind='textInput: blankArmor().armorName, autocomplete: { source: armorsPrePopFilter,
-                            onselect: populateArmor, }, hasFocus: firstModalElementHasFocus'>
+                            onselect: populateArmor }, hasFocus: firstModalElementHasFocus'>
                 </div>
               </div>
               <div class="form-group ui-front">

--- a/src/charactersheet/viewmodels/character/armor/index.html
+++ b/src/charactersheet/viewmodels/character/armor/index.html
@@ -97,7 +97,7 @@
                          id="armorAddNameInput"
                          placeholder="Chain Mail"
                          data-bind='textInput: blankArmor().armorName, autocomplete: { source: armorsPrePopFilter,
-                            onselect: populateArmor }, hasFocus: firstModalElementHasFocus'>
+                            onselect: populateArmor, }, hasFocus: firstModalElementHasFocus'>
                 </div>
               </div>
               <div class="form-group ui-front">
@@ -107,7 +107,8 @@
                   <input class="form-control"
                          id="armorAddTypeInput"
                          placeholder="Light"
-                         data-bind="textInput: blankArmor().armorType, autocomplete: { source: blankArmor().armorTypeOptions }">
+                         data-bind="textInput: blankArmor().armorType, autocomplete: { source: blankArmor().armorTypeOptions,
+                         onselect: setArmorType }">
                   </div>
               </div>
               <div class="form-group">
@@ -168,7 +169,8 @@
                   <input class="form-control"
                          id="armorAddStealthInput"
                          placeholder="Advantage"
-                         data-bind="textInput: blankArmor().armorStealth, autocomplete: { source: blankArmor().armorStealthOptions }">
+                         data-bind="textInput: blankArmor().armorStealth, autocomplete: { source: blankArmor().armorStealthOptions,
+                         onselect: setArmorStealth }">
                   </div>
               </div>
               <div class="form-group">

--- a/src/charactersheet/viewmodels/character/armor/index.js
+++ b/src/charactersheet/viewmodels/character/armor/index.js
@@ -96,6 +96,19 @@ export function ArmorViewModel() {
         }
     };
 
+    // Prepopulate methods
+
+    self.setArmorType = function(label, value) {
+        self.blankArmor().armorType(value);
+    };
+
+    self.setArmorCurrencyDenomination = function(label, value) {
+        self.blankArmor().armorCurrencyDenomination(value);
+    };
+
+    self.setArmorStealth = function(label, value) {
+        self.blankArmor().armorStealth(value);
+    };
     /* Modal Methods */
 
     self.armorsPrePopFilter = function(request, response) {

--- a/src/charactersheet/viewmodels/character/armor/index.js
+++ b/src/charactersheet/viewmodels/character/armor/index.js
@@ -109,6 +109,7 @@ export function ArmorViewModel() {
     self.setArmorStealth = function(label, value) {
         self.blankArmor().armorStealth(value);
     };
+
     /* Modal Methods */
 
     self.armorsPrePopFilter = function(request, response) {

--- a/src/charactersheet/viewmodels/character/items/index.html
+++ b/src/charactersheet/viewmodels/character/items/index.html
@@ -143,7 +143,8 @@
                       id="inventoryAddCurrencyDenominationInput"
                       placeholder="GP"
       						    data-bind="textInput: blankItem().itemCurrencyDenomination, autocomplete: {
-                          source: blankItem().itemCurrencyDenominationOptions }">
+                          source: blankItem().itemCurrencyDenominationOptions,
+                          onselect: setItemCurrencyDenomination }">
               </span>
       		   </div>
     	      </div>

--- a/src/charactersheet/viewmodels/character/items/index.js
+++ b/src/charactersheet/viewmodels/character/items/index.js
@@ -75,6 +75,11 @@ export function ItemsViewModel() {
         });
     };
 
+    // Prepopulate methods
+    self.setItemCurrencyDenomination = function(label, value) {
+        self.blankItem().itemCurrencyDenomination(value);
+    };
+
     // Modal methods
     self.modalFinishedOpening = function() {
         self.shouldShowDisclaimer(false);

--- a/src/charactersheet/viewmodels/character/magic_items/index.html
+++ b/src/charactersheet/viewmodels/character/magic_items/index.html
@@ -118,7 +118,8 @@
                          id="magicItemsAddTypeInput"
                          placeholder="Wand"
                          data-bind="textInput: blankMagicItem().magicItemType,
-                         autocomplete: { source: blankMagicItem().magicItemTypeOptions }">
+                         autocomplete: { source: blankMagicItem().magicItemTypeOptions,
+                                         onselect: setMagicItemType }">
                   </div>
               </div>
               <div class="form-group ui-front">
@@ -129,7 +130,8 @@
                          id="magicItemsAddRarityInput"
                          placeholder="Legendary"
                          data-bind="textInput: blankMagicItem().magicItemRarity,
-                         autocomplete: { source: blankMagicItem().magicItemRarityOptions }">
+                         autocomplete: { source: blankMagicItem().magicItemRarityOptions,
+                                         onselect: setMagicItemRarity }">
                   </div>
               </div>
               <div class="form-group">

--- a/src/charactersheet/viewmodels/character/magic_items/index.js
+++ b/src/charactersheet/viewmodels/character/magic_items/index.js
@@ -108,12 +108,23 @@ export function MagicItemsViewModel() {
         });
     };
 
+    // Prepopulate methods
+
     self.populateMagicItems = function(label, value) {
         var magicItems = DataRepository.magicItems[label];
 
         self.blankMagicItem().importValues(magicItems);
         self.shouldShowDisclaimer(true);
     };
+
+    self.setMagicItemType = function(label, value) {
+        self.blankMagicItem().magicItemType(value);
+    };
+
+    self.setMagicItemRarity = function(label, value) {
+        self.blankMagicItem().magicItemRarity(value);
+    };
+
 
     // Modal methods
     self.modalFinishedOpening = function() {

--- a/src/charactersheet/viewmodels/character/magic_items/index.js
+++ b/src/charactersheet/viewmodels/character/magic_items/index.js
@@ -125,7 +125,6 @@ export function MagicItemsViewModel() {
         self.blankMagicItem().magicItemRarity(value);
     };
 
-
     // Modal methods
     self.modalFinishedOpening = function() {
         self.shouldShowDisclaimer(false);

--- a/src/charactersheet/viewmodels/character/proficiencies/index.html
+++ b/src/charactersheet/viewmodels/character/proficiencies/index.html
@@ -88,7 +88,8 @@
                         id="proficiencyAddTypeInput"
                         placeholder="Weapon"
                         data-bind='textInput: blankProficiency().type,
-                        autocomplete: { source: blankProficiency().proficiencyType }'>
+                        autocomplete: { source: blankProficiency().proficiencyType,
+                                        onselect: setType}'>
               </div>
           </div>
           <div class="form-group">

--- a/src/charactersheet/viewmodels/character/proficiencies/index.js
+++ b/src/charactersheet/viewmodels/character/proficiencies/index.js
@@ -68,6 +68,10 @@ export function ProficienciesViewModel() {
         self.shouldShowDisclaimer(true);
     };
 
+    self.setType = function(label, value) {
+        self.blankProficiency().type(value);
+    };
+
     // Modal methods
     self.modalFinishedOpening = function() {
         self.shouldShowDisclaimer(false);

--- a/src/charactersheet/viewmodels/character/spells/index.html
+++ b/src/charactersheet/viewmodels/character/spells/index.html
@@ -178,7 +178,8 @@
                   <input class="form-control" id="spellsAddSchoolInput"
                          placeholder="Abjuration"
                          data-bind="textInput: blankSpell().spellSchool,
-                          autocomplete: { source: blankSpell().spellSchoolOptions }">
+                          autocomplete: { source: blankSpell().spellSchoolOptions,
+                                          onselect: setSpellSchool }">
                   </div>
               </div>
               <div class="form-group ui-front">
@@ -188,7 +189,8 @@
                   <input class="form-control" id="spellsAddTypeInput"
                          placeholder="Automatic"
                          data-bind="textInput: blankSpell().spellType,
-                          autocomplete: { source: blankSpell().spellTypeOptions }">
+                          autocomplete: { source: blankSpell().spellTypeOptions,
+                                          onselect: setSpellType }">
                   </div>
               </div>
               <div data-bind="visible: blankSpell().spellType() == 'Savings Throw'">
@@ -199,7 +201,8 @@
                     <input class="form-control" id="spellsAddSaveAttrInput"
                             placeholder="Str"
                             data-bind="textInput: blankSpell().spellSaveAttr,
-                          autocomplete: { source: blankSpell().spellSaveAttrOptions }">
+                          autocomplete: { source: blankSpell().spellSaveAttrOptions,
+                                          onselect: setSpellSaveAttr }">
                     </div>
                 </div>
               </div>
@@ -222,7 +225,8 @@
                           id="spellsAddCastTimeInput"
                           placeholder="1 action"
                           data-bind="textInput: blankSpell().spellCastingTime,
-                          autocomplete: { source: blankSpell().spellCastingTimeOptions }">
+                          autocomplete: { source: blankSpell().spellCastingTimeOptions,
+                                          onselect: setSpellCastingTime }">
                   </div>
               </div>
               <div class="form-group ui-front">
@@ -233,7 +237,8 @@
                          id="spellsAddRangeInput"
                          placeholder="1 mile"
                          data-bind="textInput: blankSpell().spellRange,
-                          autocomplete: { source: blankSpell().spellRangeOptions }">
+                          autocomplete: { source: blankSpell().spellRangeOptions,
+                                          onselect: setSpellRange }">
                   </div>
               </div>
               <div class="form-group ui-front">
@@ -244,7 +249,8 @@
                          id="spellsAddComponentsInput"
                          placeholder="V, S, M"
                          data-bind="textInput: blankSpell().spellComponents,
-                          autocomplete: { source: blankSpell().spellComponentsOptions }">
+                          autocomplete: { source: blankSpell().spellComponentsOptions,
+                                          onselect: setSpellComponents }">
                   </div>
               </div>
               <div class="form-group">
@@ -266,7 +272,8 @@
                          id="spellsAddDurationInput"
                          placeholder="1 day"
                          data-bind="textInput: blankSpell().spellDuration,
-                          autocomplete: { source: blankSpell().spellDurationOptions }">
+                          autocomplete: { source: blankSpell().spellDurationOptions,
+                                          onselect: setSpellDuration }">
                   </div>
               </div>
               <div class="form-group">

--- a/src/charactersheet/viewmodels/character/spells/index.js
+++ b/src/charactersheet/viewmodels/character/spells/index.js
@@ -80,11 +80,40 @@ export function SpellbookViewModel() {
         });
     };
 
+    // Prepopulate methods
     self.populateSpell = function(label, value) {
         var spell = DataRepository.spells[label];
 
         self.blankSpell().importValues(spell);
         self.shouldShowDisclaimer(true);
+    };
+
+    self.setSpellSchool = function(label, value) {
+        self.blankSpell().spellSchool(value);
+    };
+
+    self.setSpellType = function(label, value) {
+        self.blankSpell().spellType(value);
+    };
+
+    self.setSpellSaveAttr = function(label, value) {
+        self.blankSpell().spellSaveAttr(value);
+    };
+
+    self.setSpellCastingTime = function(label, value) {
+        self.blankSpell().spellCastingTime(value);
+    };
+
+    self.setSpellRange = function(label, value) {
+        self.blankSpell().spellRange(value);
+    };
+
+    self.setSpellComponents = function(label, value) {
+        self.blankSpell().spellComponents(value);
+    };
+
+    self.setSpellDuration = function(label, value) {
+        self.blankSpell().spellDuration(value);
     };
 
     // Modal methods

--- a/src/charactersheet/viewmodels/character/stats/index.html
+++ b/src/charactersheet/viewmodels/character/stats/index.html
@@ -133,7 +133,8 @@
               <input class="form-control"
                      placeholder="D4"
                      data-bind="textInput: editHitDiceItem().hitDiceType, autocomplete: {
-                          source: editHitDiceItem().hitDiceOptions}">
+                          source: editHitDiceItem().hitDiceOptions,
+                          onselect: setHitDiceType}">
 
             </div>
           </div>

--- a/src/charactersheet/viewmodels/character/stats/index.js
+++ b/src/charactersheet/viewmodels/character/stats/index.js
@@ -239,6 +239,11 @@ export function StatsViewModel() {
         self.healthDataHasChange();
     };
 
+    // Prepopulate methods
+    self.setHitDiceType = function(label, value) {
+        self.editHitDiceItem().hitDiceType(value);
+    };
+
     /* Utility Methods */
 
     self.deathSaveSuccessDataHasChanged = function() {

--- a/src/charactersheet/viewmodels/character/weapons/index.html
+++ b/src/charactersheet/viewmodels/character/weapons/index.html
@@ -167,7 +167,8 @@
                          id="weaponAddTypeInput"
                          placeholder="Ranged"
                          data-bind="textInput: blankWeapon().weaponType, autocomplete: {
-                          source: blankWeapon().weaponTypeOptions }">
+                          source: blankWeapon().weaponTypeOptions,
+                          onselect: setWeaponType }">
                   </div>
               </div>
               <div class="form-group ui-front">
@@ -178,7 +179,8 @@
                          id="weaponAddHandednessInput"
                          placeholder="One-Handed"
                          data-bind="textInput: blankWeapon().weaponHandedness, autocomplete: {
-                          source: blankWeapon().weaponHandednessOptions }">
+                          source: blankWeapon().weaponHandednessOptions,
+                          onselect: setWeaponHandedness }">
                   </div>
               </div>
               <div class="form-group ui-front">
@@ -189,7 +191,8 @@
                          id="weaponAddProficiencyInput"
                          placeholder="Simple"
                          data-bind="textInput: blankWeapon().weaponProficiency, autocomplete: {
-                          source: blankWeapon().weaponProficiencyOptions }">
+                          source: blankWeapon().weaponProficiencyOptions,
+                          onselect: setWeaponProficiency }">
                   </div>
               </div>
               <div class="form-group ui-front">
@@ -207,7 +210,8 @@
                              id="weaponAddCurrencyDenominationInput"
                              placeholder="GP"
                              data-bind="textInput: blankWeapon().weaponCurrencyDenomination, autocomplete: {
-                          source: blankWeapon().weaponCurrencyDenominationOptions }">
+                          source: blankWeapon().weaponCurrencyDenominationOptions,
+                          onselect: setWeaponCurrencyDenomination }">
                     </span>
                   </div>
                 </div>
@@ -241,7 +245,8 @@
                          id="weaponAddDamageTypeInput"
                          placeholder="Fire"
                          data-bind="textInput: blankWeapon().weaponDamageType, autocomplete: {
-                          source: blankWeapon().weaponDamageTypeOptions }">
+                          source: blankWeapon().weaponDamageTypeOptions,
+                          onselect: setWeaponDamageType }">
                   </div>
 
               </div>
@@ -253,7 +258,8 @@
                          id="weaponAddPropertyInput"
                          placeholder="Finesse"
                          data-bind="textInput: blankWeapon().weaponProperty, autocomplete: {
-                          source: blankWeapon().weaponPropertyOptions }">
+                          source: blankWeapon().weaponPropertyOptions,
+                          onselect: setWeaponProperty }">
                   </div>
               </div>
               <div class="form-group">

--- a/src/charactersheet/viewmodels/character/weapons/index.js
+++ b/src/charactersheet/viewmodels/character/weapons/index.js
@@ -106,7 +106,7 @@ export function WeaponsViewModel() {
             columnName, self.sorts));
     };
 
-    /* Modal Methods */
+    // Prepopulate methods
 
     self.populateWeapon = function(label, value) {
         var weapon = DataRepository.weapons[label];
@@ -114,6 +114,32 @@ export function WeaponsViewModel() {
         self.blankWeapon().importValues(weapon);
         self.shouldShowDisclaimer(true);
     };
+
+    self.setWeaponType = function(label, value) {
+        self.blankWeapon().weaponType(value);
+    };
+
+    self.setWeaponHandedness = function(label, value) {
+        self.blankWeapon().weaponHandedness(value);
+    };
+
+    self.setWeaponProficiency = function(label, value) {
+        self.blankWeapon().weaponProficiency(value);
+    };
+
+    self.setWeaponCurrencyDenomination = function(label, value) {
+        self.blankWeapon().weaponCurrencyDenomination(value);
+    };
+
+    self.setWeaponDamageType = function(label, value) {
+        self.blankWeapon().weaponDamageType(value);
+    };
+
+    self.setWeaponProperty = function(label, value) {
+        self.blankWeapon().weaponProperty(value);
+    };
+
+    /* Modal Methods */
 
     self.modalFinishedOpening = function() {
         self.shouldShowDisclaimer(false);

--- a/src/charactersheet/viewmodels/dm/encounter_sections/treasure_section/index.html
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/treasure_section/index.html
@@ -279,7 +279,8 @@
       <div class="col-sm-10">
       <input class="form-control"
               placeholder="Light"
-              data-bind="textInput: blankTreasure().armorType, autocomplete: { source: blankTreasure().armorTypeOptions }">
+              data-bind="textInput: blankTreasure().armorType, autocomplete: { source: blankTreasure().armorTypeOptions,
+              onselect: setArmorType }">
       </div>
   </div>
   <div class="form-group">
@@ -305,7 +306,8 @@
           <input class="form-control"
                  placeholder="GP"
                 data-bind="textInput: blankTreasure().armorCurrencyDenomination, autocomplete: {
-                          source: blankTreasure().armorCurrencyDenominationOptions }">
+                          source: blankTreasure().armorCurrencyDenominationOptions,
+                          onselect: setArmorCurrencyDenomination }">
         </span>
       </div>
     </div>
@@ -338,7 +340,8 @@
       <div class="col-sm-10">
       <input class="form-control"
              placeholder="Advantage"
-             data-bind="textInput: blankTreasure().armorStealth, autocomplete: { source: blankTreasure().armorStealthOptions }">
+             data-bind="textInput: blankTreasure().armorStealth, autocomplete: { source: blankTreasure().armorStealthOptions,
+             onselect: setArmorStealth }">
       </div>
   </div>
   <div class="form-group">
@@ -460,7 +463,8 @@
          <input class="form-control"
                 placeholder="GP"
                 data-bind="textInput: blankTreasure().itemCurrencyDenomination, autocomplete: {
-                          source: blankTreasure().itemCurrencyDenominationOptions }">
+                          source: blankTreasure().itemCurrencyDenominationOptions,
+                          onselect: setItemCurrencyDenomination }">
         </span>
        </div>
       </div>
@@ -500,7 +504,8 @@
         <input class="form-control"
                placeholder="Wand"
                data-bind="textInput: blankTreasure().magicItemType,
-                         autocomplete: { source: blankTreasure().magicItemTypeOptions }">
+                         autocomplete: { source: blankTreasure().magicItemTypeOptions,
+                                         onselect: setMagicItemType }">
         </div>
     </div>
     <div class="form-group ui-front">
@@ -510,7 +515,8 @@
         <input class="form-control"
                placeholder="Legendary"
                data-bind="textInput: blankTreasure().magicItemRarity,
-                         autocomplete: { source: blankTreasure().magicItemRarityOptions }">
+                         autocomplete: { source: blankTreasure().magicItemRarityOptions,
+                                         onselect: setMagicItemRarity }">
         </div>
     </div>
     <div class="form-group">
@@ -632,7 +638,8 @@
         <input class="form-control"
                placeholder="Ranged"
                data-bind="textInput: blankTreasure().weaponType, autocomplete: {
-                          source: blankTreasure().weaponTypeOptions }">
+                          source: blankTreasure().weaponTypeOptions,
+                          onselect: setWeaponType }">
         </div>
     </div>
     <div class="form-group ui-front">
@@ -642,7 +649,8 @@
         <input class="form-control"
                 placeholder="One-Handed"
                 data-bind="textInput: blankTreasure().weaponHandedness, autocomplete: {
-                          source: blankTreasure().weaponHandednessOptions }">
+                          source: blankTreasure().weaponHandednessOptions,
+                          onselect: setWeaponHandedness }">
         </div>
     </div>
     <div class="form-group ui-front">
@@ -652,7 +660,8 @@
         <input class="form-control"
                 placeholder="Simple"
                 data-bind="textInput: blankTreasure().weaponProficiency, autocomplete: {
-                          source: blankTreasure().weaponProficiencyOptions }">
+                          source: blankTreasure().weaponProficiencyOptions,
+                          onselect: setWeaponProficiency }">
         </div>
     </div>
     <div class="form-group ui-front">
@@ -669,7 +678,8 @@
             <input class="form-control"
                    placeholder="GP"
                    data-bind="textInput: blankTreasure().weaponCurrencyDenomination, autocomplete: {
-                          source: blankTreasure().weaponCurrencyDenominationOptions }">
+                          source: blankTreasure().weaponCurrencyDenominationOptions,
+                          onselect: setWeaponCurrencyDenomination }">
           </span>
         </div>
       </div>
@@ -702,7 +712,8 @@
         <input class="form-control"
                placeholder="Fire"
                data-bind="textInput: blankTreasure().weaponDamageType, autocomplete: {
-                          source: blankTreasure().weaponDamageTypeOptions }">
+                          source: blankTreasure().weaponDamageTypeOptions,
+                          onselect: setWeaponDamageType }">
         </div>
     </div>
     <div class="form-group ui-front">
@@ -712,7 +723,8 @@
         <input class="form-control"
                 placeholder="Finesse"
                 data-bind="textInput: blankTreasure().weaponProperty, autocomplete: {
-                          source: blankTreasure().weaponPropertyOptions }">
+                          source: blankTreasure().weaponPropertyOptions,
+                          onselect: setWeaponProperty }">
         </div>
     </div>
     <div class="form-group">

--- a/src/charactersheet/viewmodels/dm/encounter_sections/treasure_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/treasure_section/index.js
@@ -278,6 +278,54 @@ export function TreasureSectionViewModel(params) {
         self.shouldShowDisclaimer(true);
     };
 
+    self.setArmorType = function(label, value) {
+        self.blankTreasure().armorType(value);
+    };
+
+    self.setArmorCurrencyDenomination = function(label, value) {
+        self.blankTreasure().armorCurrencyDenomination(value);
+    };
+
+    self.setArmorStealth = function(label, value) {
+        self.blankTreasure().armorStealth(value);
+    };
+
+    self.setItemCurrencyDenomination = function(label, value) {
+        self.blankTreasure().itemCurrencyDenomination(value);
+    };
+
+    self.setMagicItemType = function(label, value) {
+        self.blankTreasure().magicItemType(value);
+    };
+
+    self.setMagicItemRarity = function(label, value) {
+        self.blankTreasure().magicItemRarity(value);
+    };
+
+    self.setWeaponType = function(label, value) {
+        self.blankTreasure().weaponType(value);
+    };
+
+    self.setWeaponHandedness = function(label, value) {
+        self.blankTreasure().weaponHandedness(value);
+    };
+
+    self.setWeaponProficiency = function(label, value) {
+        self.blankTreasure().weaponProficiency(value);
+    };
+
+    self.setWeaponCurrencyDenomination = function(label, value) {
+        self.blankTreasure().weaponCurrencyDenomination(value);
+    };
+
+    self.setWeaponDamageType = function(label, value) {
+        self.blankTreasure().weaponDamageType(value);
+    };
+
+    self.setWeaponProperty = function(label, value) {
+        self.blankTreasure().weaponProperty(value);
+    };
+
     /* Modal Methods */
 
     self.toggleModal = function() {

--- a/test/viewmodels/dm/test_treasure_section.js
+++ b/test/viewmodels/dm/test_treasure_section.js
@@ -126,6 +126,88 @@ describe('TreasureSectionViewModel', function(){
         });
     });
 
+    /* Prepopulate Methods */
+
+    describe('Should set autocomplete fields', function() {
+        it('should set the value of armor type when an autocomplete is selected', function() {
+            var armorsVM = new ArmorViewModel();
+            armorsVM.blankTreasure().armorName('Plate');
+            armorsVM.setArmorType('label', 'Light');
+
+            armorsVM.blankTreasure().armorType().should.equal('Light');
+        });
+        it('should set the value of armor currency denomination when an autocomplete is selected', function() {
+            var armorsVM = new ArmorViewModel();
+            armorsVM.blankTreasure().armorName('Plate');
+            armorsVM.setArmorCurrencyDenomination('label', 'GP');
+
+            armorsVM.blankTreasure().armorCurrencyDenomination().should.equal('GP');
+        });
+        it('should set the value of item currency denomination when an autocomplete is selected', function() {
+            var items = new ItemsViewModel();
+            items.blankTreasure().itemName('Tinder Box');
+            items.setItemCurrencyDenomination('label', 'GP');
+
+            items.blankTreasure().itemCurrencyDenomination().should.equal('GP');
+        });
+        it('should set the value of magic item type when an autocomplete is selected', function() {
+            var magicItems = new MagicItemsViewModel();
+            magicItems.blankTreasure().magicItemName('Armor of Resistence');
+            magicItems.setMagicItemType('label', 'Armor');
+
+            magicItems.blankTreasure().magicItemType().should.equal('Armor');
+        });
+        it('should set the value of magic item rarity when an autocomplete is selected', function() {
+            var magicItems = new MagicItemsViewModel();
+            magicItems.blankTreasure().magicItemName('Armor of Resistence');
+            magicItems.setMagicItemRarity('label', 'Legendary');
+
+            magicItems.blankTreasure().magicItemRarity().should.equal('Legendary');
+        });
+        it('should set the value of weapon type when an autocomplete is selected', function() {
+            var weapons = new WeaponsViewModel();
+            weapons.blankTreasure().weaponName('Sword');
+            weapons.setWeaponType('label', 'Melee');
+
+            weapons.blankTreasure().weaponType().should.equal('Melee');
+        });
+        it('should set the value of weapon handedness when an autocomplete is selected', function() {
+            var weapons = new WeaponsViewModel();
+            weapons.blankTreasure().weaponName('Sword');
+            weapons.setWeaponHandedness('label', 'One-Handed');
+
+            weapons.blankTreasure().weaponHandedness().should.equal('One-Handed');
+        });
+        it('should set the value of weapon proficiency when an autocomplete is selected', function() {
+            var weapons = new WeaponsViewModel();
+            weapons.blankTreasure().weaponName('Sword');
+            weapons.setWeaponProficiency('label', 'Simple');
+
+            weapons.blankTreasure().weaponProficiency().should.equal('Simple');
+        });
+        it('should set the value of weapon currency denomination when an autocomplete is selected', function() {
+            var weapons = new WeaponsViewModel();
+            weapons.blankTreasure().weaponName('Sword');
+            weapons.setWeaponCurrencyDenomination('label', 'GP');
+
+            weapons.blankTreasure().weaponCurrencyDenomination().should.equal('GP');
+        });
+        it('should set the value of weapon damage type when an autocomplete is selected', function() {
+            var weapons = new WeaponsViewModel();
+            weapons.blankTreasure().weaponName('Sword');
+            weapons.setWeaponDamageType('label', 'Acid');
+
+            weapons.blankTreasure().weaponDamageType().should.equal('Acid');
+        });
+        it('should set the value of weapon property when an autocomplete is selected', function() {
+            var weapons = new WeaponsViewModel();
+            weapons.blankTreasure().weaponName('Sword');
+            weapons.setWeaponProperty('label', 'Finesse');
+
+            weapons.blankTreasure().weaponProperty().should.equal('Finesse');
+        });
+    });
+
     /* UI Methods */
 
     describe('Sort By', function() {

--- a/test/viewmodels/test_armor.js
+++ b/test/viewmodels/test_armor.js
@@ -179,6 +179,23 @@ describe('ArmorViewModel', function(){
         });
     });
 
+    describe('Should set autocomplete fields', function() {
+        it('should set the value of armor type when an autocomplete is selected', function() {
+            var armorsVM = new ArmorViewModel();
+            armorsVM.blankArmor().armorName('Plate');
+            armorsVM.setArmorType('label', 'Light');
+
+            armorsVM.blankArmor().armorType().should.equal('Light');
+        });
+        it('should set the value of armor currency denomination when an autocomplete is selected', function() {
+            var armorsVM = new ArmorViewModel();
+            armorsVM.blankArmor().armorName('Plate');
+            armorsVM.setArmorCurrencyDenomination('label', 'GP');
+
+            armorsVM.blankArmor().armorCurrencyDenomination().should.equal('GP');
+        });
+    });
+
     describe('Modal Finished Closing', function() {
         it('should switch default state to preview', function() {
             var armorsVM = new ArmorViewModel();

--- a/test/viewmodels/test_items.js
+++ b/test/viewmodels/test_items.js
@@ -157,15 +157,15 @@ describe('InventoryViewModel', function(){
             });
         });
 
-    describe('Should set autocomplete fields', function() {
-        it('should set the value of item currency denomination when an autocomplete is selected', function() {
-            var items = new ItemsViewModel();
-            items.blankItem().itemName('Tinder Box');
-            items.setItemCurrencyDenomination('label', 'GP');
+        describe('Should set autocomplete fields', function() {
+            it('should set the value of item currency denomination when an autocomplete is selected', function() {
+                var items = new ItemsViewModel();
+                items.blankItem().itemName('Tinder Box');
+                items.setItemCurrencyDenomination('label', 'GP');
 
-            items.blankItem().itemCurrencyDenomination().should.equal('GP');
+                items.blankItem().itemCurrencyDenomination().should.equal('GP');
+            });
         });
-    });
 
         describe('Modal Finished Closing', function() {
             it('should switch default state to preview', function() {

--- a/test/viewmodels/test_items.js
+++ b/test/viewmodels/test_items.js
@@ -157,6 +157,16 @@ describe('InventoryViewModel', function(){
             });
         });
 
+    describe('Should set autocomplete fields', function() {
+        it('should set the value of item currency denomination when an autocomplete is selected', function() {
+            var items = new ItemsViewModel();
+            items.blankItem().itemName('Tinder Box');
+            items.setItemCurrencyDenomination('label', 'GP');
+
+            items.blankItem().itemCurrencyDenomination().should.equal('GP');
+        });
+    });
+
         describe('Modal Finished Closing', function() {
             it('should switch default state to preview', function() {
                 var items = new ItemsViewModel();

--- a/test/viewmodels/test_magic_items.js
+++ b/test/viewmodels/test_magic_items.js
@@ -128,6 +128,23 @@ describe('Magic Items View Model', function(){
         });
     });
 
+    describe('Should set autocomplete fields', function() {
+        it('should set the value of magic item type when an autocomplete is selected', function() {
+            var magicItems = new MagicItemsViewModel();
+            magicItems.blankMagicItem().magicItemName('Armor of Resistence');
+            magicItems.setMagicItemType('label', 'Armor');
+
+            magicItems.blankMagicItem().magicItemType().should.equal('Armor');
+        });
+        it('should set the value of magic item rarity when an autocomplete is selected', function() {
+            var magicItems = new MagicItemsViewModel();
+            magicItems.blankMagicItem().magicItemName('Armor of Resistence');
+            magicItems.setMagicItemRarity('label', 'Legendary');
+
+            magicItems.blankMagicItem().magicItemRarity().should.equal('Legendary');
+        });
+    });
+
     describe('Select Preview Tab', function() {
         it('should switch to preview tab status', function() {
             var magicItems = new MagicItemsViewModel();

--- a/test/viewmodels/test_proficiencies.js
+++ b/test/viewmodels/test_proficiencies.js
@@ -115,6 +115,16 @@ describe('ProficienciesViewModel', function() {
         });
     });
 
+    describe('Should set autocomplete fields', function() {
+        it('should set the value of proficiency type when an autocomplete is selected', function() {
+            var proficienciesViewModel = new ProficienciesViewModel();
+            proficienciesViewModel.blankProficiency().name('Bagpipes');
+            proficienciesViewModel.setType('label', 'Tools');
+
+            proficienciesViewModel.blankProficiency().type().should.equal('Tools');
+        });
+    });
+
     describe('Sort By', function() {
         it('should sort the list of proficiencies by given criteria', function() {
             var proficienciesViewModel = new ProficienciesViewModel();

--- a/test/viewmodels/test_spells.js
+++ b/test/viewmodels/test_spells.js
@@ -160,4 +160,56 @@ describe('SpellsViewModel', function(){
             book.preparedRowVisibleEdit(spell).should.equal(false);
         });
     });
+
+    describe('Should set autocomplete fields', function() {
+        it('should set the value of spell school when an autocomplete is selected', function() {
+            var book = new SpellbookViewModel();
+            book.blankSpell().spellLevel(1);
+            book.setSpellSchool('label', 'Fire');
+
+            book.blankSpell().spellSchool().should.equal('Fire');
+        });
+        it('should set the value of spell type when an autocomplete is selected', function() {
+            var book = new SpellbookViewModel();
+            book.blankSpell().spellLevel(1);
+            book.setSpellType('label', 'Attack Roll');
+
+            book.blankSpell().spellType().should.equal('Attack Roll');
+        });
+        it('should set the value of spell save attr when an autocomplete is selected', function() {
+            var book = new SpellbookViewModel();
+            book.blankSpell().spellLevel(1);
+            book.setSpellSaveAttr('label', 'Wis');
+
+            book.blankSpell().spellSaveAttr().should.equal('Wis');
+        });
+        it('should set the value of spell casting time when an autocomplete is selected', function() {
+            var book = new SpellbookViewModel();
+            book.blankSpell().spellLevel(1);
+            book.setSpellCastingTime('label', '1 action');
+
+            book.blankSpell().spellCastingTime().should.equal('1 action');
+        });
+        it('should set the value of spell range when an autocomplete is selected', function() {
+            var book = new SpellbookViewModel();
+            book.blankSpell().spellLevel(1);
+            book.setSpellRange('label', '20 ft.');
+
+            book.blankSpell().spellRange().should.equal('20 ft.');
+        });
+        it('should set the value of spell components when an autocomplete is selected', function() {
+            var book = new SpellbookViewModel();
+            book.blankSpell().spellLevel(1);
+            book.setSpellComponents('label', 'S');
+
+            book.blankSpell().spellComponents().should.equal('S');
+        });
+        it('should set the value of spell duration when an autocomplete is selected', function() {
+            var book = new SpellbookViewModel();
+            book.blankSpell().spellLevel(1);
+            book.setSpellDuration('label', '1 hour');
+
+            book.blankSpell().spellDuration().should.equal('1 hour');
+        });
+    });
 });

--- a/test/viewmodels/test_stats.js
+++ b/test/viewmodels/test_stats.js
@@ -1,5 +1,5 @@
-import { CharacterManager } from 'charactersheet/utilities';
 import { HitDice, HitDiceType } from 'charactersheet/models/character';
+import { CharacterManager } from 'charactersheet/utilities';
 import { MockCharacterManager } from '../mocks';
 import { PersistenceService } from 'charactersheet/services/common/persistence_service';
 import Should from 'should';
@@ -145,7 +145,7 @@ describe('Stats View Model', function() {
             var stats = new StatsViewModel();
             var hitDie = new HitDiceType();
             hitDie.hitDiceType('D6');
-            stats.editHitDiceItem(hitDie)
+            stats.editHitDiceItem(hitDie);
             stats.setHitDiceType('label', 'D12');
             stats.editHitDiceItem().hitDiceType().should.equal('D12');
         });

--- a/test/viewmodels/test_stats.js
+++ b/test/viewmodels/test_stats.js
@@ -1,5 +1,5 @@
 import { CharacterManager } from 'charactersheet/utilities';
-import { HitDice } from 'charactersheet/models/character';
+import { HitDice, HitDiceType } from 'charactersheet/models/character';
 import { MockCharacterManager } from '../mocks';
 import { PersistenceService } from 'charactersheet/services/common/persistence_service';
 import Should from 'should';
@@ -137,6 +137,17 @@ describe('Stats View Model', function() {
                 stats.health().tempHitpoints().should.equal(val.tempHitpoints);
                 stats.health().damage().should.equal(val.damage);
             });
+        });
+    });
+
+    describe('Should set autocomplete fields', function() {
+        it('should set the value of hit dice type when an autocomplete is selected', function() {
+            var stats = new StatsViewModel();
+            var hitDie = new HitDiceType();
+            hitDie.hitDiceType('D6');
+            stats.editHitDiceItem(hitDie)
+            stats.setHitDiceType('label', 'D12');
+            stats.editHitDiceItem().hitDiceType().should.equal('D12');
         });
     });
 

--- a/test/viewmodels/test_weapons.js
+++ b/test/viewmodels/test_weapons.js
@@ -144,4 +144,49 @@ describe('WeaponsViewModel', function(){
         });
     });
 
+    describe('Should set autocomplete fields', function() {
+        it('should set the value of weapon type when an autocomplete is selected', function() {
+            var weapons = new WeaponsViewModel();
+            weapons.blankWeapon().weaponName('Sword');
+            weapons.setWeaponType('label', 'Melee');
+
+            weapons.blankWeapon().weaponType().should.equal('Melee');
+        });
+        it('should set the value of weapon handedness when an autocomplete is selected', function() {
+            var weapons = new WeaponsViewModel();
+            weapons.blankWeapon().weaponName('Sword');
+            weapons.setWeaponHandedness('label', 'One-Handed');
+
+            weapons.blankWeapon().weaponHandedness().should.equal('One-Handed');
+        });
+        it('should set the value of weapon proficiency when an autocomplete is selected', function() {
+            var weapons = new WeaponsViewModel();
+            weapons.blankWeapon().weaponName('Sword');
+            weapons.setWeaponProficiency('label', 'Simple');
+
+            weapons.blankWeapon().weaponProficiency().should.equal('Simple');
+        });
+        it('should set the value of weapon currency denomination when an autocomplete is selected', function() {
+            var weapons = new WeaponsViewModel();
+            weapons.blankWeapon().weaponName('Sword');
+            weapons.setWeaponCurrencyDenomination('label', 'GP');
+
+            weapons.blankWeapon().weaponCurrencyDenomination().should.equal('GP');
+        });
+        it('should set the value of weapon damage type when an autocomplete is selected', function() {
+            var weapons = new WeaponsViewModel();
+            weapons.blankWeapon().weaponName('Sword');
+            weapons.setWeaponDamageType('label', 'Acid');
+
+            weapons.blankWeapon().weaponDamageType().should.equal('Acid');
+        });
+        it('should set the value of weapon property when an autocomplete is selected', function() {
+            var weapons = new WeaponsViewModel();
+            weapons.blankWeapon().weaponName('Sword');
+            weapons.setWeaponProperty('label', 'Finesse');
+
+            weapons.blankWeapon().weaponProperty().should.equal('Finesse');
+        });
+    });
+
 });


### PR DESCRIPTION
### Summary of Changes

Fixes persisting items when selected from an autocomplete dropdown. Fixes an issue where two elements required 2 downclicks to select an item in the weapons module. Fixes issue where spell save attr wouldn't show if Savings Throw was selected in the spell type field.

### Issues Fixed

Fixes #1743 
Fixes #1741 
Fixes #1739
