### PR TITLE
Reimplements validation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "hypnos": "git+https://github.com/adventurerscodex/hypnos.git",
     "jquery": "^3.2.1",
     "jquery-ui": "^1.12.1",
+    "jquery-validation": "^1.17.0",
     "knockout": "~3.3.0",
     "knockout-mapping": "^2.6.0",
     "less": "^2.7.2",

--- a/src/bin/knockout-validation.js
+++ b/src/bin/knockout-validation.js
@@ -1,0 +1,41 @@
+import $ from 'jquery';
+import ko from 'knockout';
+import 'jquery-validation';
+
+/**
+* Binds a form element to use jQuery validation tools
+* The argument should be a an object of settings from jQuery Validate.
+*
+* jQuery Validation Docs:
+* https://jqueryvalidation.org/validate/
+*
+* Usage Example
+* -------------
+*  <form class="form-horizontal" data-bind="validate: validationSettings">
+*    <!-- Inputs in a validated form must have a name. -->
+*    <input name="name" value="" type="text" />
+*    <!-- Either buttons or input[type=submit] works fine.. -->
+*    <input type="submit" value="Add" />
+*  </form>
+*
+*/
+ko.bindingHandlers.validate = {
+    init: (element, valueAccessor) => {
+        const value = valueAccessor();
+
+        // Add a new handler callback that adds the form as a param for
+        // checking overall validity.
+        // Preserve the old onfocusout in case it was being used.
+        value.ogonfocusout = value.onfocusout;
+        value.onfocusout = (input, event) => {
+            if (value.updateHandler) {
+                value.updateHandler($(element), input);
+            }
+            if (value.ogonfocusout) {
+                value.ogonfocusout(input, event);
+            }
+        };
+
+        $(element).validate(ko.unwrap(value));
+    }
+};

--- a/src/charactersheet/init.js
+++ b/src/charactersheet/init.js
@@ -1,5 +1,6 @@
 // Enables Async/Await
 import 'babel-polyfill';
+import 'bin/knockout-validation';
 import {
     AuthenticationServiceManager,
     ChatServiceManager,

--- a/src/charactersheet/viewmodels/character/features/index.html
+++ b/src/charactersheet/viewmodels/character/features/index.html
@@ -12,8 +12,11 @@
             <span data-bind="css: sortArrow('characterClass')"></span>
           </th>
           <th class="col-md-1">
-            <a data-toggle="modal"
-              data-target="#addFeature" id="featureAddIcon" href="#">
+            <a
+              id="featureAddIcon"
+              href="#"
+              data-bind="click: toggleAddModal"
+            >
               <i class="fa fa-plus fa-color"></i>
             </a>
           </th>
@@ -34,8 +37,11 @@
       <!-- /ko -->
       <!-- ko if: filteredAndSortedFeatures().length == 0 -->
         <tr class="clickable">
-          <td data-toggle="modal" data-target="#addFeature" href="#"
-            colspan="12" class="text-center">
+          <td
+            data-bind="click: toggleAddModal"
+            colspan="12"
+            class="text-center"
+          >
             <i class="fa fa-plus fa-color"></i>
             Add a new Feature
           </td>
@@ -51,7 +57,10 @@
      id="addFeature"
      tabindex="-1"
      role="dialog" data-bind="modal: {
-      onopen: modalFinishedOpening, onclose: modalFinishedClosing}">
+      open: addModalOpen,
+      onopen: modalFinishedOpening,
+      onclose: modalFinishedClosing
+    }">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
@@ -65,11 +74,12 @@
             id="addFeatureLabel">Add a new Feature.</h4>
       </div>
       <div class="modal-body">
-        <form class="form-horizontal">
+        <form class="form-horizontal" data-bind="validate: validation">
           <div class="form-group ui-front">
             <label for="name" class="col-sm-2 control-label">Name</label>
               <div class="col-sm-10">
                 <input type="text"
+                        name="name"
                         class="form-control"
                         id="featureAddNameInput"
                         placeholder="Rage"
@@ -159,11 +169,11 @@
             </div>
           </div>
           <div class="modal-footer">
-            <button type="button"
+            <button type="submit"
                     class="btn btn-primary"
                     id="featureAddAddButton"
-                    data-bind='click: addFeature'
-                    data-dismiss="modal">Add</button>
+                    data-bind='disable: !addFormIsValid()'
+                  >Add</button>
             <p class="text-muted text-left" data-bind='visible: shouldShowDisclaimer'>
               <sm><i>This data is distributed under the
                 <a href='http://media.wizards.com/2016/downloads/DND/SRD-OGL_V5.1.pdf'

--- a/src/charactersheet/viewmodels/character/features/index.js
+++ b/src/charactersheet/viewmodels/character/features/index.js
@@ -17,6 +17,7 @@ import ko from 'knockout';
 import meditation from 'images/meditation.svg';
 import template from './index.html';
 import uuid from 'node-uuid';
+import validation from './validation';
 
 export function FeaturesViewModel() {
     var self = this;
@@ -33,7 +34,9 @@ export function FeaturesViewModel() {
     self.features = ko.observableArray([]);
     self.blankFeature = ko.observable(new Feature());
     self.blankTracked = ko.observable(new Tracked());
+    self.addModalOpen = ko.observable(false);
     self.modalOpen = ko.observable(false);
+    self.addFormIsValid = ko.observable(false);
     self.editItemIndex = null;
     self.currentEditItem = ko.observable(new Feature());
     self.currentEditTracked = ko.observable(new Tracked());
@@ -86,6 +89,22 @@ export function FeaturesViewModel() {
     };
 
     // Modal methods
+
+    self.validation = {
+        submitHandler: (form) => {
+            self.addFeature();
+        },
+        updateHandler: ($element) => {
+            self.addFormIsValid($element.valid());
+        },
+        rules: validation.rules,
+        messages: validation.messages
+    };
+
+    self.toggleAddModal = () => {
+        self.addModalOpen(!self.addModalOpen());
+    };
+
     self.modalFinishedOpening = function() {
         self.shouldShowDisclaimer(false);
         self.firstModalElementHasFocus(true);
@@ -146,6 +165,8 @@ export function FeaturesViewModel() {
         self.features.push(newFeature.object);
         self.blankFeature(new Feature());
         self.blankTracked(new Tracked());
+
+        self.toggleAddModal();
     };
 
     self.clear = function() {

--- a/src/charactersheet/viewmodels/character/features/validation.js
+++ b/src/charactersheet/viewmodels/character/features/validation.js
@@ -1,0 +1,10 @@
+export default {
+     rules: {
+         name: {
+             required: true
+         }
+     },
+     messages: {
+ //         name: "Please give me your name...",
+     }
+ };


### PR DESCRIPTION
ORIGINAL COMMIT MESSAGE:

Adds a new validation framework and an example in Features. (#1769)
* Adds a new validation framework and an example in Features.

- Using the new validation, we can apply form validation to all modals
and other places.
- The Features has been updated to have an example of how to use this
new validation including a new validation.js with the common rules for
add/edit modals.
- There is still work to be done in the handling of updates and
submissions but this should get us close enough for now.

* Removes debugging statement

* Removes old data modal handler

* Preserves the original onfocusout functionality.

* Adds documentation and usage example

* Fixes linting

* Fixes linting II...the relintining

* Fixes linting again..

### Summary of Changes



### Issues Fixed



### Changes Proposed (if any)



### Screen Shot of Proposed Changes (if UI related)


