### PR TITLE
Initial implementation of preview edit component.

### DIFF
--- a/src/charactersheet/components/index.js
+++ b/src/charactersheet/components/index.js
@@ -3,4 +3,5 @@ import { ImagePickerComponentViewModel } from './image-picker';
 import { MarkdownEditPreviewComponentViewModel } from './markdown-edit-preview';
 import { NestedListComponentViewModel } from './nested-list';
 import { PlusMinusComponentViewModel } from './plus-minus';
+import { PreviewEditViewModel } from './preview-edit';
 import { ProficiencyTypeComponentViewModel } from './proficiency-marker';

--- a/src/charactersheet/components/preview-edit.js
+++ b/src/charactersheet/components/preview-edit.js
@@ -1,0 +1,51 @@
+import ko from 'knockout';
+/**
+ * This component provides a generic template for controlling and displaying forms in a preview and
+ * edit mode.
+ *
+ * @param {*} params contains observables and other data from the parent viewmodel
+ *                   - data: this observable holds the data used to render both the forms
+ *                   - save: this is a javascript function used to save the edited data
+ *                   - validation: this javascript object conatains the validation constraints to
+ *                     be used in the form validation
+ */
+export function PreviewEditViewModel(params) {
+    var self = this;
+
+    self.data = params.data;
+    self.save = params.save;
+    self.validationConstraints = params.validation;
+    self.isEditFormValid = ko.observable(false);
+    self.isEdit = ko.observable(false);
+
+    self.toggleEditForm = () => {
+        self.isEdit(!self.isEdit());
+    };
+
+    self.saveAndToggleForm = async () => {
+        await self.save();
+        self.toggleEditForm();
+    };
+
+    self.validation = {
+        updateHandler: ($element) => {
+            self.isEditFormValid($element.valid());
+        },
+        // Deep copy of properties in object
+        ...self.validationConstraints
+    };
+}
+
+ko.components.register('preview-edit', {
+    viewModel: PreviewEditViewModel,
+    template: '\
+        <!-- ko if: isEdit -->\
+        <button type="button"\
+                class="btn btn-sm btn-primary pull-right"\
+                data-bind="click: saveAndToggleForm, disable: !isEditFormValid()">\
+        Save\
+        </button>\
+        <!-- /ko -->\
+        <!-- ko template: { nodes: $componentTemplateNodes, data: data } -->\
+        <!-- /ko -->'
+});

--- a/src/charactersheet/components/preview-edit.js
+++ b/src/charactersheet/components/preview-edit.js
@@ -1,4 +1,5 @@
 import ko from 'knockout';
+
 /**
  * This component provides a generic template for controlling and displaying forms in a preview and
  * edit mode.
@@ -9,30 +10,32 @@ import ko from 'knockout';
  *                   - validation: this javascript object conatains the validation constraints to
  *                     be used in the form validation
  */
-export function PreviewEditViewModel(params) {
-    var self = this;
+export class PreviewEditViewModel {
 
-    self.data = params.data;
-    self.save = params.save;
-    self.validationConstraints = params.validation;
-    self.isEditFormValid = ko.observable(false);
-    self.isEdit = ko.observable(false);
+    isEditFormValid = ko.observable(false);
+    isEdit = ko.observable(false);
 
-    self.toggleEditForm = () => {
-        self.isEdit(!self.isEdit());
+    constructor(params) {
+        this.data = params.data;
+        this.save = params.save;
+        this.validationConstraints = params.validation;
+    }
+
+    toggleEditForm = () => {
+        this.isEdit(!this.isEdit());
     };
 
-    self.saveAndToggleForm = async () => {
-        await self.save();
-        self.toggleEditForm();
+    saveAndToggleForm = async () => {
+        await this.save();
+        this.toggleEditForm();
     };
 
-    self.validation = {
+    validation = {
         updateHandler: ($element) => {
-            self.isEditFormValid($element.valid());
+            this.isEditFormValid($element.valid());
         },
         // Deep copy of properties in object
-        ...self.validationConstraints
+        ...this.validationConstraints
     };
 }
 

--- a/src/charactersheet/models/character/background.js
+++ b/src/charactersheet/models/character/background.js
@@ -18,3 +18,11 @@ export class Background extends KOModel {
     bond = ko.observable('');
     personalityTrait = ko.observable('');
 }
+
+Background.validationConstraints = {
+    rules: {
+        name: {
+            maxlength: 128
+        }
+    }
+};

--- a/src/charactersheet/viewmodels/character/background/index.html
+++ b/src/charactersheet/viewmodels/character/background/index.html
@@ -1,46 +1,96 @@
 <div class="panel panel-default">
-  <div class="panel-body" data-bind="with: background">
   <div class="panel-body">
-    <div class="form-horizontal">
-      <div class="form-group">
-        <div class="row">
-          <div class="col-md-offset-4 col-md-4 col-padded">
-            <div class="input-group">
-              <span class="input-group-addon" id="basic-addon2">Background</span>
-              <input type="text"
-                      class="form-control"
-                      id="profileBackgroundInput"
-                      aria-describedby="basic-addon2"
-                      data-bind='value: name,
-                      autocomplete: { source: $parent.backgroundOptions,
-                      onselect: $parent.setBackground }' />
+    <preview-edit params="validation: validation,
+                          data: background,
+                          save: save">
+      <!-- ko if: $component.isEdit -->
+      <div class="panel-body">
+        <form class="form-horizontal" data-bind="validate: $component.validation">
+          <div class="form-group">
+            <div class="row">
+              <div class="col-md-4 col-padded">
+                <label for="profileBackgroundInput">Background:</label>
+                <input type="text"
+                        class="form-control"
+                        id="profileBackgroundInput"
+                        name="name"
+                        aria-describedby="basic-addon2"
+                        data-bind='value: name' />
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-md-6 col-padded">
+                <label for="backgroundTraitsTextarea">Personality Traits:</label>
+                <textarea id="backgroundTraitsTextarea"
+                          class="form-control dark-area"
+                          rows="4"
+                          data-bind="value: personalityTrait">
+                </textarea>
+              </div>
+              <div class="col-md-6 col-padded">
+                <label for="backgroundIdealsTextarea">Ideals:</label>
+                <textarea id="backgroundIdealsTextarea"
+                          class="form-control dark-area"
+                          rows="4"
+                          data-bind="value: ideal">
+                </textarea>
+              </div>
+              <div class="col-md-6 col-padded">
+                <label for="backgroundBondsTextarea">Bonds:</label>
+                <textarea id="backgroundBondsTextarea"
+                          class="form-control dark-area"
+                          rows="4"
+                          data-bind="value: bond">
+                </textarea>
+              </div>
+              <div class="col-md-6 col-padded">
+                <label for="backgroundFlawsTextarea">Flaws:</label>
+                <textarea id="backgroundFlawsTextarea"
+                          class="form-control dark-area"
+                          rows="4"
+                          data-bind="value: flaw">
+                </textarea>
+              </div>
             </div>
           </div>
+        </form>
+      </div>
+      <!-- /ko -->
+
+      <!-- ko ifnot: $component.isEdit -->
+      <div class="row">
+        <div class="col-sm-11 col-xs-12">
+          <h3 data-bind="text: name"></h3>
         </div>
-        <div class="row">
-          <div class="col-md-6 col-padded">
-          <label for="backgroundArea">Personality Traits:</label>
-            <textarea id="backgroundTraitsTextarea" class="form-control dark-area" rows="4"
-              data-bind="value: personalityTrait"></textarea>
+        <div class="col-sm-1">
+          <span class="fa fa-pencil-square-o fa-color-hover-success fa-lg clickable pull-right"
+          data-bind="click: $component.toggleEditForm">
+          </span>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-6 col-padded">
+          <label for="backgroundTraitsTextarea">Personality Traits:</label>
+          <div data-bind="text: personalityTrait">
           </div>
-          <div class="col-md-6 col-padded">
-          <label for="idealsArea">Ideals:</label>
-            <textarea id="backgroundIdealsTextarea" class="form-control dark-area" rows="4"
-              data-bind="value: ideal"></textarea>
+        </div>
+        <div class="col-md-6 col-padded">
+          <label for="backgroundIdealsTextarea">Ideals:</label>
+          <div data-bind="text: ideal">
           </div>
-          <div class="col-md-6 col-padded">
-          <label for="bondsArea">Bonds:</label>
-            <textarea id="backgroundBondsTextarea" class="form-control dark-area" rows="4"
-              data-bind="value: bond"></textarea>
+        </div>
+        <div class="col-md-6 col-padded">
+          <label for="backgroundBondsTextarea">Bonds:</label>
+          <div data-bind="text: bond">
           </div>
-          <div class="col-md-6 col-padded">
-          <label for="flawsArea">Flaws:</label>
-            <textarea id="backgroundFlawsTextarea" class="form-control dark-area" rows="4"
-              data-bind="value: flaw"></textarea>
+        </div>
+        <div class="col-md-6 col-padded">
+          <label for="backgroundFlawsTextarea">Flaws:</label>
+          <div data-bind="text: flaw">
           </div>
         </div>
       </div>
-    </div>
-  </div>
+      <!-- /ko -->
+    </preview-edit>
   </div>
 </div>

--- a/src/charactersheet/viewmodels/character/background/index.html
+++ b/src/charactersheet/viewmodels/character/background/index.html
@@ -15,7 +15,9 @@
                         id="profileBackgroundInput"
                         name="name"
                         aria-describedby="basic-addon2"
-                        data-bind='value: name' />
+                        data-bind='value: name,
+                        autocomplete: { source: $parents[1].backgroundOptions,
+                        onselect: $parents[1].setBackground }' />
               </div>
             </div>
             <div class="row">

--- a/src/charactersheet/viewmodels/character/background/index.js
+++ b/src/charactersheet/viewmodels/character/background/index.js
@@ -1,7 +1,6 @@
 import { Background } from 'charactersheet/models/character';
 import { CoreManager } from 'charactersheet/utilities';
 import { Fixtures } from 'charactersheet/utilities';
-import { Notifications } from 'charactersheet/utilities';
 import ko from 'knockout';
 import template from './index.html';
 
@@ -10,28 +9,26 @@ export function BackgroundViewModel() {
 
     self.background = ko.observable(new Background());
     self.backgroundOptions = Fixtures.profile.backgroundOptions;
+    self.validation = {};
 
     self.load = async () => {
         var key = CoreManager.activeCore().uuid();
         const response = await Background.ps.read({uuid: key});
         self.background(response.object);
-
-        // Subscriptions
-        self.background().personalityTrait.subscribe(self.dataHasChanged);
-        self.background().ideal.subscribe(self.dataHasChanged);
-        self.background().flaw.subscribe(self.dataHasChanged);
-        self.background().bond.subscribe(self.dataHasChanged);
-        self.background().name.subscribe(self.dataHasChanged);
     };
 
     self.setBackground = function(label, value) {
         self.background().name(value);
     };
 
-    self.dataHasChanged = async () => {
+    self.save = async () => {
         await self.background().ps.save();
     };
 
+    self.validation = {
+        // Deep copy of properties in object
+        ...Background.validationConstraints
+    };
 }
 
 ko.components.register('background', {

--- a/src/charactersheet/viewmodels/character/magic_items/index.html
+++ b/src/charactersheet/viewmodels/character/magic_items/index.html
@@ -433,5 +433,4 @@
         </div> <!-- Modal Content -->
       </div> <!-- Modal Dialog -->
     </div> <!-- Modal Fade -->
-
 </div> <!-- Panel -->


### PR DESCRIPTION
### Summary of Changes

Adds component to manage a preview and edit form.

### Issues and possible enhancements

- This implementation does not allow for autocomplete fields in the edit view. This functionality should still exist, but I was not able to think of a decent enough solution.
- A nice thing to have would be to put the edit/preview form in its own `.html` file. I tried to do that, but I wasn't able to inject it using the `template` binding due to scoping issues. This issue could be addressed by simply passing the template to the component, but this method was advised against by some.