### PR TITLE
Local Storage % removed from modal + PS uses sessionStorage now.

### DIFF
--- a/src/charactersheet/services/common/persistence_service.js
+++ b/src/charactersheet/services/common/persistence_service.js
@@ -8,7 +8,7 @@ export var PersistenceService = {
     enableCompression: false,
     master: '__master__',
     version: '__version__',
-    storage: localStorage,
+    storage: sessionStorage,
     registry: {}
 };
 

--- a/src/charactersheet/viewmodels/common/characters/index.html
+++ b/src/charactersheet/viewmodels/common/characters/index.html
@@ -64,11 +64,6 @@
         </div>
       </div>
       <div class="modal-footer">
-        <div class='pull-left'>
-          <p class="text-left">
-            You've used <span data-bind='text: localStoragePercent'></span>% of your total local space.
-          </p>
-        </div>
         <button type="button" class="btn btn-primary pull-right"
           data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">Done</span>

--- a/src/charactersheet/viewmodels/common/characters/index.js
+++ b/src/charactersheet/viewmodels/common/characters/index.js
@@ -96,12 +96,6 @@ export function CharactersViewModel(params) {
         return '';
     };
 
-    self.localStoragePercent = ko.computed(() => {
-        self.cores(); //Force ko to recompute on change.
-        var used = JSON.stringify(localStorage).length / (0.5 * 1024 * 1024);
-        return (used / self.totalLocalStorage * 100).toFixed(2);
-    });
-
     // Private Methods
 
     self._updatedSelectedCharacter = () => {

--- a/src/charactersheet/viewmodels/common/characters/index.js
+++ b/src/charactersheet/viewmodels/common/characters/index.js
@@ -10,7 +10,6 @@ import template from './index.html';
 export function CharactersViewModel(params) {
     var self = this;
 
-    self.totalLocalStorage = 5; //MB
     self.cores = ko.observableArray([]);
     self.componentStatus = params.modalStatus || ko.observable(false);
     self.modalStatus = ko.observable(false);


### PR DESCRIPTION
### Summary of Changes

- Persistence Service no longer uses localStorage. It has switched over to sessionStorage.
- The characters modal no longer shows the percent of local storage used.