### PR TITLE
Remove spell.damageType as a required field

### DIFF
--- a/src/charactersheet/models/common/spell.js
+++ b/src/charactersheet/models/common/spell.js
@@ -104,8 +104,7 @@ Spell.validationConstraints = {
             maxlength: 128
         },
         damageType: {
-            maxlength: 128,
-            required: true
+            maxlength: 128
         },
         school: {
             maxlength: 128,

--- a/src/charactersheet/viewmodels/character/spells/index.html
+++ b/src/charactersheet/viewmodels/character/spells/index.html
@@ -240,7 +240,7 @@
               <div class="form-group">
                 <label for="damageType"
                        class="col-sm-3 control-label">
-                       Damage Type<i class="required"></i>
+                       Damage Type
                       </label>
                   <div class="col-sm-9">
                     <input type="text"
@@ -544,7 +544,7 @@
                   <div class="form-group">
                     <label for="damage"
                            class="col-sm-3 control-label">
-                           Damage Type<i class="required"></i>
+                           Damage Type
                           </label>
                       <div class="col-sm-9">
                         <input type="text"


### PR DESCRIPTION
### Summary of Changes

This field was required and shouldn't be.
