### PR TITLE
Users that are not registered are now redirected to their account profile

### DIFF
--- a/src/charactersheet/services/common/account/authentication_service.js
+++ b/src/charactersheet/services/common/account/authentication_service.js
@@ -91,14 +91,12 @@ function _AuthenticationService(config) {
     };
 
     self._handleValidationFailure = function(request, status) {
-        if (request.status === 401) {
-            // We got a 401 so the token is probably invalid.
-            self._goToLogin();
-        } else if (request.status === 403) {
+        if (request.status === 403) {
             // The user hasn't registered their account.
             self._goToAccount();
         } else {
-            throw Error("Unknown authentication failure");
+            // We probably got a 401 so the token is probably invalid.
+            self._goToLogin();
         }
     };
 

--- a/src/charactersheet/services/common/account/authentication_service.js
+++ b/src/charactersheet/services/common/account/authentication_service.js
@@ -62,8 +62,12 @@ function _AuthenticationService(config) {
     // Private Methods
 
     self._doAuthCheck = function(accessToken) {
-        Utility.oauth.getJSON(self.validationUrl, self._handleValidationSuccess,
-            self._handleValidationFailure, accessToken);
+        Utility.oauth.getJSON(
+            self.validationUrl,
+            self._handleValidationSuccess,
+            self._handleValidationFailure,
+            accessToken
+        );
     };
 
     self._handleValidationSuccess = function(data, status) {
@@ -88,31 +92,33 @@ function _AuthenticationService(config) {
 
     self._handleValidationFailure = function(request, status) {
         var token = PersistenceService.findAll(AuthenticationToken)[0];
-        if (self._tokenOrigin == self.TOKEN_ORIGINS.FRAGMENT) {
-            // Retry with local token.
-            self._tokenOrigin = self.TOKEN_ORIGINS.LOCAL;
-            if (token) {
-                self._doAuthCheck(token.accessToken());
-            }
-        } else {
+        if (!self._tokenOrigin === self.TOKEN_ORIGINS.FRAGMENT) {
             // All tokens are invalid and should be removed.
             if (token) {
                 token.delete();
             }
             // Redirect to login
             self._goToLogin();
+            return;
         }
 
-        // Alert the user of the error.
-        var message = request.responseJSON.detail || 'An error has occurred.';
-        Notifications.userNotification.warningNotification.dispatch(message, null, {
-            timeOut: 0,
-            extendedTimeOut: 0
-        });
+        // Retry with local token.
+        self._tokenOrigin = self.TOKEN_ORIGINS.LOCAL;
+        if (token) {
+            self._doAuthCheck(token.accessToken());
+            return;
+        }
+
+        // The user might not have registered or otherwise cannot access the app.
+        self._goToAccount();
     };
 
     self._goToLogin = () => {
         window.location = LOGIN_URL.replace('{CLIENT_ID}', CLIENT_ID);
+    };
+
+    self._goToAccount = () => {
+        window.location = ACCOUNT_URL;
     };
 
     self._remove_info_and_set_new_url = () => {

--- a/src/charactersheet/services/common/account/authentication_service.js
+++ b/src/charactersheet/services/common/account/authentication_service.js
@@ -91,7 +91,7 @@ function _AuthenticationService(config) {
     };
 
     self._handleValidationFailure = function(request, status) {
-         if (request.status === 401) {
+        if (request.status === 401) {
             // We got a 401 so the token is probably invalid.
             self._goToLogin();
         } else if (request.status === 403) {

--- a/src/charactersheet/services/common/account/authentication_service.js
+++ b/src/charactersheet/services/common/account/authentication_service.js
@@ -91,26 +91,15 @@ function _AuthenticationService(config) {
     };
 
     self._handleValidationFailure = function(request, status) {
-        var token = PersistenceService.findAll(AuthenticationToken)[0];
-        if (!self._tokenOrigin === self.TOKEN_ORIGINS.FRAGMENT) {
-            // All tokens are invalid and should be removed.
-            if (token) {
-                token.delete();
-            }
-            // Redirect to login
+         if (request.status === 401) {
+            // We got a 401 so the token is probably invalid.
             self._goToLogin();
-            return;
+        } else if (request.status === 403) {
+            // The user hasn't registered their account.
+            self._goToAccount();
+        } else {
+            throw Error("Unknown authentication failure");
         }
-
-        // Retry with local token.
-        self._tokenOrigin = self.TOKEN_ORIGINS.LOCAL;
-        if (token) {
-            self._doAuthCheck(token.accessToken());
-            return;
-        }
-
-        // The user might not have registered or otherwise cannot access the app.
-        self._goToAccount();
     };
 
     self._goToLogin = () => {

--- a/src/charactersheet/services/common/index.js
+++ b/src/charactersheet/services/common/index.js
@@ -1,4 +1,3 @@
-
 export { CharacterCardPublishingService } from './sync/card_service.js';
 export { DMCardPublishingService } from './sync/card_service.js';
 export { HotkeysService } from './hotkeys_service.js';

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -43,6 +43,10 @@ module.exports = merge(common, {
              */
             'HOME_URL': JSON.stringify('/'),
             /**
+             * The URL of the user's account profile.
+             */
+            'ACCOUNT_URL': JSON.stringify('/accounts/profile/'),
+            /**
              * The URL to the login page.
              */
             'LOGIN_URL': JSON.stringify('/api/o/authorize?client_id={CLIENT_ID}&response_type=token'),

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -66,6 +66,10 @@ module.exports = merge(common, {
              */
             'HOME_URL': process.env.HOME_URL,
             /**
+             * The URL of the user's account profile.
+             */
+            'ACCOUNT_URL': process.env.ACCOUNT_URL,
+            /**
              * The URL to the login page.
              */
             'LOGIN_URL': process.env.LOGIN_URL,


### PR DESCRIPTION
### Summary of Changes

There, on their accounts page, they can resend their registration email. This essentially prohibits un-registered users from using AC.

This should eliminate a lot of confusion around the current blank page that a user sees that tells them nothing about why they can't use the app.

### Issues Fixed

None logged.

### Changes Proposed (if any)

N/A

### Screen Shot of Proposed Changes (if UI related)

N/A