### PR TITLE
Weapons now count quantity towards weight

### DIFF
--- a/src/charactersheet/viewmodels/character/weapons/index.js
+++ b/src/charactersheet/viewmodels/character/weapons/index.js
@@ -70,7 +70,7 @@ export function WeaponsViewModel() {
         }
 
         const weightTotal = self.weapons().map(
-            weapon => weapon.weight()
+            weapon => weapon.totalWeight()
         ).reduce(
             (a, b) => a + b
         );


### PR DESCRIPTION
### Summary of Changes

- Weapons now count quantity towards weight
- The ticket mentioned armor and magic items, but they have no quantity so they're already correct.

### Issues Fixed

None logged.

### Changes Proposed (if any)

N/A

### Screen Shot of Proposed Changes (if UI related)

N/A