### PR TITLE
Ensure that the user only sees green connection status when both connected *and* authenticated

### DIFF
--- a/src/charactersheet/viewmodels/common/player_image/index.js
+++ b/src/charactersheet/viewmodels/common/player_image/index.js
@@ -46,8 +46,8 @@ export function PlayerImageViewModel() {
         Notifications.coreManager.changed.add(self.dataHasChanged);
 
         // Prime the pump.
-        await self.dataHasChanged();
         self._handleConnectionStatusChanged();
+        await self.dataHasChanged();
     };
 
     self.doneButtonClicked = async () => {
@@ -142,7 +142,12 @@ export function PlayerImageViewModel() {
 
     self._handleConnectionStatusChanged = function() {
         var xmpp = XMPPService.sharedService();
-        self._isConnectedToXMPP(xmpp.connection ? xmpp.connection.connected : null);
+        self._isConnectedToXMPP(
+            xmpp.connection ?
+            // Ensure we're both connected and authenticated.
+            (xmpp.connection.connected && xmpp.connection.authenticated) :
+            false
+        );
     };
 
     //Player Image Handlers


### PR DESCRIPTION
### Summary of Changes

Previous checks only ensured the user was connected. Now we check both connection status and authentication status.

I've also moved the check of status above the await since this would cause lag in first detection.

### Issues Fixed

None logged.

### Changes Proposed (if any)

N/A

### Screen Shot of Proposed Changes (if UI related)

N/A
