### PR TITLE
Hides the share button for DMs.

### DIFF
--- a/src/charactersheet/viewmodels/common/root/index.html
+++ b/src/charactersheet/viewmodels/common/root/index.html
@@ -47,11 +47,13 @@
             <i class="fa fa-users"></i>&nbsp;&nbsp;Manage Party
           </a>
         </li>
+        <!-- ko if: selectedCore().type.name() != 'dm' -->
         <li>
           <a data-bind="click: toggleShareModal" href="#">
             <i class="fa fa-share-square-o"></i>&nbsp;&nbsp;Share
           </a>
         </li>
+        <!-- /ko -->
       </ul>
       <login></login>
     </div>


### PR DESCRIPTION
### Summary of Changes

Hides share button for DM in order to release Character share first.

### Screen Shot of Proposed Changes (if UI related)

![image](https://user-images.githubusercontent.com/7286387/60478847-af9e4e80-9c38-11e9-96c2-1f69fe525818.png)

![image](https://user-images.githubusercontent.com/7286387/60478875-c8a6ff80-9c38-11e9-8b6d-30eab67874e7.png)

