### PR TITLE
Bumps bundling version of node to LTS.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Build Step
 #
 
-FROM node:8 as builder
+FROM node:14 as builder
 MAINTAINER Brian Schrader
 WORKDIR /app
 


### PR DESCRIPTION
### Summary of Changes

I did extensive testing between the two and found that if you bump the version and build the app, there is literally no difference in the files.

    $ diff v8/main.js v14/main.js # Finds no difference

We should bump the version to stay supported. v14 is the LTS release.

**NOTE:** I did find several differences when comparing the docker-built version (using Node 8 & 14) with the one built by the version of Node I had installed on macOS. This is concerning, but is mostly just informational atm.

### Issues Fixed

N/A

### Changes Proposed (if any)

N/A

### Screen Shot of Proposed Changes (if UI related)

N/A
