### PR TITLE
Adds new POI DC check fields.

### DIFF
--- a/src/charactersheet/models/dm/encounter_sections/point_of_interest.js
+++ b/src/charactersheet/models/dm/encounter_sections/point_of_interest.js
@@ -19,6 +19,8 @@ export class PointOfInterest extends KOModel {
     name = ko.observable('');
     playerText = ko.observable();
     sourceUrl = ko.observable();
+    difficultyCheckValue = ko.observable();
+    difficultyCheckSkill = ko.observable();
     description = ko.observable('');
 
     // UI Methods

--- a/src/charactersheet/utilities/fixtures.js
+++ b/src/charactersheet/utilities/fixtures.js
@@ -600,6 +600,32 @@ export var Fixtures = {
             }
         }
     },
+    difficultyCheckOptions: [
+        'Acrobatics',
+        'Animal Handling',
+        'Arcana',
+        'Athletics',
+        'Charisma',
+        'Constitution',
+        'Deception',
+        'Dexterity',
+        'History',
+        'Insight',
+        'Intelligence',
+        'Intimidation',
+        'Investigation',
+        'Medicine',
+        'Nature',
+        'Perception',
+        'Performance',
+        'Persuasion',
+        'Religion',
+        'Sleight of Hand',
+        'Stealth',
+        'Strength',
+        'Survival',
+        'Wisdom',
+    ],
     import: {
         masterTable: [
             'Character','Profile','PlayerInfo','Skill','CharacterAppearance','FeaturesTraits','ImageModel','Health','OtherStats','DeathSave','HitDiceType','AbilityScores','SavingThrows','SpellStats','FeatsProf','Treasure','Note','HitDice','Slot','Item','Spell','Armor','Weapon','MagicItem','Status','PlayerImage','Campaign','DailyFeature','Encounter','EnvironmentSection','PointOfInterestSection','NPCSection','MonsterSection','PlayerTextSection','TreasureSection','NotesSection','Environment','Proficiency','Feat','Feature','Tracked','Trait','AuthenticationToken','ChatRoom','ChatMessage','PlayerText','PointOfInterest','MonsterAbilityScore','Monster','NPC','EncounterItem','Presence','Message','MapsAndImagesSection','MapOrImage','CampaignMapOrImage','Exhibit','EncounterMagicItem'

--- a/src/charactersheet/viewmodels/character/wealth/view.html
+++ b/src/charactersheet/viewmodels/character/wealth/view.html
@@ -77,20 +77,19 @@
       </div>
       <div class="col-xs-12">
         <form data-bind="submit: $component.quickSpend">
-          <div class="input-group input-group-sm">
+          <div class="input-group input-group-sm d-flex">
             <input
               type="number"
               minvalue="1"
               required
-              class="form-control"
+              class="form-control d-flex-4"
               placeholder="Quick spend"
               data-bind="value: $component.quickSpendAmount"
             >
-            <span class="input-group-btn" style="width: 33%;">
+            <span class="input-group-btn d-flex-3">
               <select
                 required
                 class="form-control"
-                style="padding: 2px;"
                 data-bind="value: $component.quickSpendCoinType"
               >
                 <option value="copper">CP</option>
@@ -100,7 +99,7 @@
                 <option value="platinum">PP</option>
               </select>
             </span>
-            <span class="input-group-btn">
+            <span class="input-group-btn d-flex-3">
               <button
                 class="btn btn-default"
                 type="submit"

--- a/src/charactersheet/viewmodels/dm/encounter_sections/point_of_interest_section/index.html
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/point_of_interest_section/index.html
@@ -141,6 +141,33 @@
               </span>
             </div>
           </div>
+          <div class="form-group ui-front">
+            <label class="col-sm-2 control-label">
+              Required DC
+            </label>
+            <div class="col-sm-4">
+              <input type="number"
+                      name="difficultyCheckValue"
+                      class="form-control d-flex-1"
+                      data-bind="value: blankPointOfInterest().difficultyCheckValue"
+                      placeholder="15"
+              />
+            </div>
+            <div class="col-sm-5">
+              <input
+                type="text"
+                name="difficultyCheckSkill"
+                class="form-control"
+                placeholder="Perception"
+                data-bind="
+                  textInput: blankPointOfInterest().difficultyCheckSkill,
+                  autocomplete: {
+                    source: difficultyCheckSkillPrePopFilter,
+                    onselect: populateDifficutyCheckSkill
+                  }"
+                />
+            </div>
+          </div>
           <div class="form-group">
             <label class="col-sm-2 control-label">Description</label>
             <div class="col-sm-9">
@@ -182,6 +209,15 @@
             </small>
             <button type="submit"
                     class="btn btn-primary">Add</button>
+            <p class="text-muted text-left" data-bind="visible: showDisclaimer">
+              <sm><i>This data is distributed under the
+                <a href="http://media.wizards.com/2016/downloads/DND/SRD-OGL_V5.1.pdf"
+                  target="_blank">
+                  OGL</a><br/>
+                  Open	Game	License	v	1.0a	Copyright	2000,	Wizards	of	the	Coast,	LLC.
+                </i>
+              </sm>
+            </p>
           </div>
         </form>
       </div> <!-- Modal Body -->
@@ -224,12 +260,21 @@
         </ul>
         <div class="tab-content" data-bind="with: currentEditItem">
           <div role="tabpanel" data-bind="css: $parent.previewTabStatus" class="tab-pane">
-            <div class="h3">
-              <span data-bind="text: name"></span>&nbsp;
+            <div class="d-flex">
+              <div class="h3 d-flex-2">
+                <span data-bind="text: name"></span>&nbsp;
+              </div>
+              <!-- ko if: difficultyCheckValue() || difficultyCheckSkill() -->
+              <div class="h3 d-flex-1 text-muted">
+                <small>
+                  DC:&nbsp;<span data-bind="text: difficultyCheckValue"></span>&nbsp;<span data-bind="text: difficultyCheckSkill"></span>
+                </small>
+              </div>
+              <!-- /ko -->
             </div>
             <!-- ko if: sourceUrl -->
             <div class="row row-padded">
-              <div class="col-xs-12 col-padded text-center">
+              <div class="col-xs-12 col-padded text-center image-container">
                 <img data-bind="attr: { src: $parent.convertedDisplayUrl },
                   click: $parent.toggleFullScreen" class="clickable preview-modal-image" />
                 <small>
@@ -292,6 +337,33 @@
                   <span class="fa fa-paper-plane-o" style="cursor:pointer;"
                     title="This field will be sent to the players via the chat.">
                   </span>
+                </div>
+              </div>
+              <div class="form-group">
+                <label class="col-sm-2 control-label">
+                  Required DC
+                </label>
+                <div class="col-sm-4">
+                  <input type="number"
+                          name="difficultyCheckValue"
+                          class="form-control"
+                          data-bind="textInput: difficultyCheckValue"
+                          placeholder="15"
+                  >
+                </div>
+                <div class="col-sm-5">
+                  <input
+                    type="text"
+                    name="difficultyCheckSkill"
+                    class="form-control"
+                    placeholder="Perception"
+                    data-bind="
+                      textInput: difficultyCheckSkill,
+                      autocomplete: {
+                        source: $component.difficultyCheckSkillPrePopFilter,
+                        onselect: $component.populateDifficutyCheckSkill
+                      }"
+                  />
                 </div>
               </div>
               <div class="form-group">

--- a/src/charactersheet/viewmodels/dm/encounter_sections/point_of_interest_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/point_of_interest_section/index.js
@@ -6,7 +6,7 @@ import {
     CoreManager,
     Fixtures,
     Notifications,
-    Utility,
+    Utility
 } from 'charactersheet/utilities';
 import { PointOfInterest } from 'charactersheet/models/dm';
 import ko from 'knockout';
@@ -209,7 +209,6 @@ export function PointOfInterestSectionViewModel(params) {
         const results = Fixtures.difficultyCheckOptions.filter(function(name, idx, _) {
             return name.toLowerCase().indexOf(term) > -1;
         });
-        console.log(response, term, results);
         response(results);
     };
 

--- a/src/charactersheet/viewmodels/dm/encounter_sections/point_of_interest_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/point_of_interest_section/index.js
@@ -6,7 +6,7 @@ import {
     CoreManager,
     Fixtures,
     Notifications,
-    Utility
+    Utility,
 } from 'charactersheet/utilities';
 import { PointOfInterest } from 'charactersheet/models/dm';
 import ko from 'knockout';
@@ -40,6 +40,7 @@ export function PointOfInterestSectionViewModel(params) {
     self.addFormIsValid = ko.observable(false);
     self.addModalOpen = ko.observable(false);
     self.fullScreen = ko.observable(false);
+    self.showDisclaimer = ko.observable(false);
 
     // Push to Player
     self.selectedPoiToPush = ko.observable();
@@ -201,6 +202,20 @@ export function PointOfInterestSectionViewModel(params) {
         self.editTabStatus('active');
         self.previewTabStatus('');
         self.editFirstModalElementHasFocus(true);
+    };
+
+    self.difficultyCheckSkillPrePopFilter = function(request, response) {
+        const term = request.term.toLowerCase();
+        const results = Fixtures.difficultyCheckOptions.filter(function(name, idx, _) {
+            return name.toLowerCase().indexOf(term) > -1;
+        });
+        console.log(response, term, results);
+        response(results);
+    };
+
+    self.populateDifficutyCheckSkill = function(skill, value) {
+        self.blankPointOfInterest().difficultyCheckSkill(skill);
+        self.showDisclaimer(true);
     };
 
     /* Push to Player Methods */

--- a/src/style/site.css
+++ b/src/style/site.css
@@ -2090,3 +2090,38 @@ tr .panel {
   border: 1px solid #18bc9c;
   background-color: #fff;
 }
+
+/* Fix for BS 3 selects as input-group-btn */
+.input-group-btn>select.form-control {
+  padding: 2px;
+}
+
+/* Bootstrap Flex Addons */
+
+.d-flex {
+  display: flex;
+}
+
+.d-flex-1 {
+  flex: 1;
+}
+
+.d-flex-2 {
+  flex: 2;
+}
+
+.d-flex-3 {
+  flex: 3;
+}
+
+.d-flex-4 {
+  flex: 4;
+}
+
+.d-flex-5 {
+  flex: 5;
+}
+
+.d-flex-6 {
+  flex: 6;
+}


### PR DESCRIPTION
### Summary of Changes

These fields are optional and do not block submissions nor apply to old POIs.

This commit also adds some new flex utilities present in Bootstrap 4/5 but not in 3 and they're really nice.

This commit also redoes the Wealth Quick Spend to use these new utilities.

POI DC checks can be set to any text and number value, but the skill autopopulates the basic skills and stats.

This change requires the backend change merged as well.

### Issues Fixed

Fixes #1551 

### Changes Proposed (if any)

N/A

### Screen Shot of Proposed Changes (if UI related)

#### POI with DC
<img width="572" alt="Screen Shot 2021-10-28 at 1 17 25 PM" src="https://user-images.githubusercontent.com/3310280/139329986-991d9d9f-49a8-4e2f-97b2-b877bed01f35.png">

#### POI without DC
<img width="579" alt="Screen Shot 2021-10-28 at 1 17 38 PM" src="https://user-images.githubusercontent.com/3310280/139329989-3ba55e44-06d1-4399-9822-a7da2d9bfe30.png">

#### POI Form

<img width="577" alt="Screen Shot 2021-10-28 at 1 24 15 PM" src="https://user-images.githubusercontent.com/3310280/139330118-568ce49f-89bf-45c1-a8b8-97b3794f2b4c.png">

