### PR TITLE
Fixes up Navbar display on small screens and cleans up code

### DIFF
--- a/src/charactersheet/viewmodels/common/login/index.html
+++ b/src/charactersheet/viewmodels/common/login/index.html
@@ -1,32 +1,52 @@
-<ul class="nav navbar-nav navbar-right">
-  <!-- ko ifnot: loggedIn -->
-  <li class="secondary-nav">
-    <a data-bind="attr: { href: loginLink }">
-      Login
-    </a>
-  </li>
-  <li class="secondary-nav">
-    <a data-bind="attr: { href: signupLink }">
-      Sign Up
-    </a>
-  </li>
-  <!-- /ko -->
-  <!-- ko if: loggedIn -->
+<!-- ko if: loggedIn -->
+<!-- SM-LG Supplementary Nav -->
+<ul class="nav navbar-nav navbar-right hidden-xs">
   <li class="dropdown">
-    <a href="#" class="dropdown-toggle" data-toggle="dropdown"
-      role="button" aria-haspopup="true" aria-expanded="false">
-        <span data-bind="text: username"></span>
-        <span class="caret"></span>
+    <a
+      href="#"
+      class="dropdown-toggle"
+      data-toggle="dropdown"
+      role="button"
+      aria-haspopup="true"
+      aria-expanded="false"
+    >
+      <span data-bind="text: username"></span>
+      <span class="caret"></span>
     </a>
     <ul class="dropdown-menu">
-      <li><a href="/accounts/profile/">Account</a></li>
+      <li>
+        <a href="/accounts/profile/" title="User Profile">
+          <i class="fa fa-user"></i>&nbsp;&nbsp;Account
+        </a>
+      </li>
       <li role="separator" class="divider"></li>
       <li class="secondary-nav">
-        <a data-bind="click: logoutLinkWasClicked, attr: { href: _logoutLink }">
-          <span>Logout</span>
+        <a
+          title="Logout"
+          data-bind="click: logoutLinkWasClicked, attr: { href: _logoutLink }"
+        >
+          <span><i class="fa fa-sign-out"></i>&nbsp;&nbsp;Logout</span>
         </a>
       </li>
     </ul>
   </li>
-  <!-- /ko -->
 </ul>
+
+<!-- XS Supplementary Nav -->
+<ul class="nav navbar-nav navbar-right visible-xs">
+  <li>
+    <a href="/accounts/profile/" title="User Profile">
+      <i class="fa fa-user"></i>&nbsp;&nbsp;Account
+    </a>
+  </li>
+  <li role="separator" class="divider"></li>
+  <li class="secondary-nav">
+    <a
+      title="Logout"
+      data-bind="click: logoutLinkWasClicked, attr: { href: _logoutLink }"
+    >
+      <span><i class="fa fa-sign-out"></i>&nbsp;&nbsp;Logout</span>
+    </a>
+  </li>
+</ul>
+<!-- /ko -->

--- a/src/charactersheet/viewmodels/common/root/index.html
+++ b/src/charactersheet/viewmodels/common/root/index.html
@@ -30,18 +30,22 @@
             <span class="sr-only">Toggle navigation</span> <span class="icon-bar"></span>
             <span class="icon-bar"></span><span class="icon-bar"></span>
           </button>
-          <a data-bind="attr: { href: homeURL }, css: { 'navbar-divider': shouldShowApp }"
-              class="navbar-brand">
-            <img data-bind="attr: { src: navLogo }"
-                class="pull-left img-rounded inline-block brand-icon resize_logo_nav"
-                alt="Adventurer's Codex" />
-            <span class="inline-block pull-right">Adventurer's Codex</span>
+          <a
+            data-bind="attr: { href: homeURL }"
+            title="Adventurer's Codex"
+            class="navbar-brand"
+          >
+            <img
+              data-bind="attr: { src: navLogo }"
+              class="pull-left img-rounded inline-block brand-icon resize_logo_nav"
+              alt="Adventurer's Codex"
+            />
+            <span class="inline-block pull-right hidden-xs">Adventurer's Codex</span>
           </a>
         </div>
-        <!-- ko if: shouldShowApp -->
-        <div id="navbar"
-            class="collapse navbar-collapse">
+        <div id="navbar" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
+            <!-- ko if: shouldShowApp -->
             <li>
               <a data-toggle="modal"
                   data-target="#newModal"
@@ -51,15 +55,8 @@
             <li>
               <a data-bind="click: toggleCharacterAndGamesModal"
                   href="#">
-                <i class="fa fa-address-card"></i>&nbsp;&nbsp;Characters and Games </a>
+                <i class="fa fa-address-card"></i>&nbsp;&nbsp;Characters &amp; Games </a>
             </li>
-<!--
-            <li>
-              <a data-bind="click: togglePartyManagerModal"
-                  href="#">
-                <i class="fa fa-users"></i>&nbsp;&nbsp;Manage Party </a>
-            </li>
- -->
             <!-- ko if: selectedCore() && selectedCore().type.name() != 'dm' -->
             <li>
               <a data-bind="click: toggleShareModal"
@@ -67,7 +64,7 @@
                 <i class="fa fa-share-square-o"></i>&nbsp;&nbsp;Share </a>
             </li>
             <!-- /ko -->
-            <li>
+            <li class="visible-xs visible-lg">
               <a
                 href="https://www.patreon.com/bePatron?u=5313385"
                 class="btn-support-us"
@@ -76,13 +73,10 @@
               >
                 <i class="fa fa-usd"></i>&nbsp;&nbsp;Support Us </a>
             </li>
+            <!-- /ko -->
           </ul>
           <login></login>
         </div>
-        <!-- /ko -->
-        <!-- ko ifnot: shouldShowApp -->
-        <login></login>
-        <!-- /ko -->
         <!--/.nav-collapse -->
       </div>
     </div>


### PR DESCRIPTION
### Summary of Changes

The navbar used to be kinda broken on small devices and would overflow onto two lines. This is fixed.

Also our navbar would collapse on small devices, but the dropdown would still exist. This essentially gave us two collapsed navbars, one inside of the other. This was very bad for UX. This is also fixed.

This commit also adds some accessibility features (titles for links).

I've also added more iconography to spice things up.

### Issues Fixed

N/A

### Changes Proposed (if any)

N/A

### Screen Shot of Proposed Changes (if UI related)

<img width="1201" alt="Screen Shot 2021-10-28 at 11 24 30 PM" src="https://user-images.githubusercontent.com/3310280/139386038-d7475474-9013-496b-a4c8-0f5805f3c23c.png">
<img width="1205" alt="Screen Shot 2021-10-28 at 11 24 58 PM" src="https://user-images.githubusercontent.com/3310280/139386061-32418228-67c0-4c70-8c96-6ccb7fce155f.png">
<img width="338" alt="Screen Shot 2021-10-28 at 11 24 40 PM" src="https://user-images.githubusercontent.com/3310280/139386057-b6530b81-88dc-43b7-8ebe-a31e9bc5d4b5.png">
<img width="333" alt="Screen Shot 2021-10-28 at 11 24 46 PM" src="https://user-images.githubusercontent.com/3310280/139386058-ac648056-e32b-487b-9c6d-2b9e0d84fd9a.png">

