### PR TITLE
This dependency does nothing and breaks our test builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "dependencies": {
     "auto-bind": "^2.1.0",
-    "babel": "^6.23.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.4",


### PR DESCRIPTION
### Summary of Changes

Removes NoOp dependency.

From the console: 

```
npm WARN deprecated babel@6.23.0: In 6.x, the babel package has been deprecated in favor of babel-cli. Check https://opencollective.com/babel to support the Babel maintainers
```

### Issues Fixed

N/A

### Changes Proposed (if any)

N/A

### Screen Shot of Proposed Changes (if UI related)

N/A
