### PR TITLE
Fixes typo that caused Monster Senses not to be displayed properly.

### DIFF
--- a/src/charactersheet/viewmodels/dm/encounter_sections/monster_section/view.html
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/monster_section/view.html
@@ -120,9 +120,9 @@
           <th scope="row">Skills</th>
           <td data-bind="markdownPreview: skills"></td>
         </tr>
-        <tr data-bind="visible: skills">
+        <tr data-bind="visible: senses">
           <th scope="row">Senses</th>
-          <td data-bind="markdownPreview: skills"></td>
+          <td data-bind="markdownPreview: senses"></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
### Summary of Changes

There was a typo. Senses instead displayed skills. 

### Issues Fixed

Fixes #2086 

### Changes Proposed (if any)

N/A

### Screen Shot of Proposed Changes (if UI related)

N/A