### PR TITLE
Standardizes Card Layout + Adds Values for HP/Stats/Spells to Card.

### DIFF
--- a/src/charactersheet/viewmodels/common/player_card/index.html
+++ b/src/charactersheet/viewmodels/common/player_card/index.html
@@ -52,6 +52,10 @@
       <div class="row">
         <div class="col-xs-12" data-bind="visible: player.maxHitPoints">
           Hit Points
+          <span class="text-muted pull-right">
+            <small data-bind="text: currentHp()"></small> /
+            <small data-bind="text: currentMaxHp()"></small>
+          </span>
           <div class="progress thin">
             <div class="progress thin">
               <div
@@ -78,9 +82,13 @@
           </div>
         </div>
       </div>
-      <div class="row" data-bind="visible: player.totalSpellSlots">
+      <div class="row">
         <div class="col-xs-12">
           Spell Slots
+          <span class="text-muted pull-right">
+            <small data-bind="text: currentSpellSlots()"></small> /
+            <small data-bind="text: currentMaxSpellSlots()"></small>
+          </span>
           <div class="progress thin">
             <div
               class="progress-bar progress-bar-info"
@@ -93,9 +101,13 @@
           </div>
         </div>
       </div>
-      <div class="row" data-bind="visible: player.totalTrackables">
+      <div class="row">
         <div class="col-xs-12">
           Features, Feats, and Traits
+          <span class="text-muted pull-right">
+            <small data-bind="text: currentTrackables()"></small> /
+            <small data-bind="text: currentMaxTrackables()"></small>
+          </span>
           <div class="progress thin">
             <div
               class="progress-bar progress-bar-warning"
@@ -111,33 +123,33 @@
       <div class="row">
         <div class="col-xs-12 col-padded">
           <table class="table table-striped table-condensed">
-            <tr data-bind="visible: player.armorClass">
+            <tr>
               <th scope="row">Armor Class</th>
-              <td data-bind="text: player.armorClass"></td>
+              <td data-bind="text: player.armorClass || 0"></td>
             </tr>
-            <tr data-bind="visible: player.hitDice">
+            <tr>
               <th scope="row">Hit Dice</th>
-              <td data-bind="text: player.hitDice"></td>
+              <td data-bind="text: player.hitDice || 0"></td>
             </tr>
-            <tr data-bind="visible: player.spellSaveDc">
+            <tr>
               <th scope="row">Spell Save DC</th>
-              <td data-bind="text: player.spellSaveDc"></td>
+              <td data-bind="text: player.spellSaveDc || 0"></td>
             </tr>
-            <tr data-bind="visible: player.experience">
+            <tr>
               <th scope="row">Experience</th>
-              <td data-bind="text: player.experience"></td>
+              <td data-bind="text: player.experience || 0"></td>
             </tr>
-            <tr data-bind="visible: player.passivePerception">
+            <tr>
               <th scope="row">Passive Perception</th>
-              <td data-bind="text: player.passivePerception"></td>
+              <td data-bind="text: player.passivePerception || 0"></td>
             </tr>
-            <tr data-bind="visible: player.passiveInvestigation">
+            <tr>
               <th scope="row">Passive Investigation</th>
-              <td data-bind="text: player.passiveInvestigation"></td>
+              <td data-bind="text: player.passiveInvestigation || 0"></td>
             </tr>
-            <tr data-bind="visible: player.worthInGold">
+            <tr>
               <th scope="row">Gold</th>
-              <td data-bind="text: '~' + player.worthInGold"></td>
+              <td data-bind="text: '~' + player.worthInGold || 0"></td>
             </tr>
           </table>
         </div>

--- a/src/charactersheet/viewmodels/common/player_card/index.js
+++ b/src/charactersheet/viewmodels/common/player_card/index.js
@@ -29,18 +29,30 @@ export class PlayerCardViewModel extends ViewModel {
 
     // UI
 
+    currentMaxHp() {
+        return this.player.maxHitPoints - this.player.maxHitPointsReductionDamage;
+    }
+
+    currentHp() {
+        return this.currentMaxHp() - this.currentDamage();
+    }
+
+    currentTempHp() {
+        return this.player.tempHitPoints;
+    }
+
+    currentDamage() {
+        return this.player.damage;
+    }
+
     hpPercent() {
         return (
-            (this.player.maxHitPoints - this.player.maxHitPointsReductionDamage - this.player.damage)
-                / (this.player.maxHitPoints - this.player.maxHitPointsReductionDamage + this.player.tempHitPoints)
+            (this.currentHp()) / (this.currentMaxHp() + this.currentTempHp())
         );
     }
 
     tempHpPercent() {
-        return (
-            this.player.tempHitPoints
-                / (this.player.maxHitPoints - this.player.maxHitPointsReductionDamage + this.player.tempHitPoints)
-        );
+        return (this.currentTempHp() / (this.currentMaxHp() + this.currentTempHp()));
     }
 
     hpProgressBarCss() {
@@ -54,12 +66,28 @@ export class PlayerCardViewModel extends ViewModel {
         }
     }
 
+    currentSpellSlots() {
+        return this.player.remainingSpellSlots;
+    }
+
+    currentMaxSpellSlots() {
+        return this.player.totalSpellSlots;
+    }
+
     spellSlotPercent() {
-        return (this.player.remainingSpellSlots / this.player.totalSpellSlots);
+        return (this.currentSpellSlots() / this.currentMaxSpellSlots());
+    }
+
+    currentTrackables() {
+        return this.player.remainingTrackables;
+    }
+
+    currentMaxTrackables() {
+        return this.player.totalTrackables;
     }
 
     trackedPercent() {
-        return (this.player.remainingTrackables / this.player.totalTrackables);
+        return (this.currentTrackables() / this.currentMaxTrackables());
     }
 
     statusIndicatorClass = pureComputed(() => (


### PR DESCRIPTION
### Summary of Changes

This commit ensures that cards are more readable by being the same height. This makes the cards much easier to glance at and read since they read row by row rather than jumping around.

This commit also exposes the underlying HP/Spell Slots/Trackables numbers to make it easier for the DM to gauge the actual values of their players.


### Issues Fixed

None

### Changes Proposed (if any)

None

### Screen Shot of Proposed Changes (if UI related)

<img width="1269" alt="Screen Shot 2022-11-27 at 1 06 50 PM" src="https://user-images.githubusercontent.com/3310280/204159736-8869a7c0-3037-42da-b408-7bf1d1b5f06b.png">
