### PR TITLE
Fixes issue with player card fields showing for players when they shouldn't

### DIFF
--- a/src/charactersheet/viewmodels/common/player_card/index.html
+++ b/src/charactersheet/viewmodels/common/player_card/index.html
@@ -50,7 +50,7 @@
       </div>
       <!-- Health, Spells, and Features  -->
       <div class="row">
-        <div class="col-xs-12" data-bind="visible: player.maxHitPoints">
+        <div class="col-xs-12" data-bind="visible: player.maxHitPoints !== undefined">
           Hit Points
           <span class="text-muted pull-right">
             <small data-bind="text: currentHp()"></small> /
@@ -83,7 +83,7 @@
         </div>
       </div>
       <div class="row">
-        <div class="col-xs-12">
+        <div class="col-xs-12" data-bind="visible: player.totalSpellSlots !== undefined">
           Spell Slots
           <span class="text-muted pull-right">
             <small data-bind="text: currentSpellSlots()"></small> /
@@ -102,7 +102,7 @@
         </div>
       </div>
       <div class="row">
-        <div class="col-xs-12">
+        <div class="col-xs-12" data-bind="visible: player.totalTrackables !== undefined">
           Features, Feats, and Traits
           <span class="text-muted pull-right">
             <small data-bind="text: currentTrackables()"></small> /
@@ -121,7 +121,7 @@
         </div>
       </div>
       <div class="row">
-        <div class="col-xs-12 col-padded">
+        <div class="col-xs-12 col-padded" data-bind="visible: hasStats">
           <table class="table table-striped table-condensed">
             <tr>
               <th scope="row">Armor Class</th>

--- a/src/charactersheet/viewmodels/common/player_card/index.html
+++ b/src/charactersheet/viewmodels/common/player_card/index.html
@@ -49,8 +49,8 @@
         </div>
       </div>
       <!-- Health, Spells, and Features  -->
-      <div class="row">
-        <div class="col-xs-12" data-bind="visible: player.maxHitPoints !== undefined">
+      <div class="row" data-bind="visible: isDM">
+        <div class="col-xs-12">
           Hit Points
           <span class="text-muted pull-right">
             <small data-bind="text: currentHp()"></small> /
@@ -82,8 +82,8 @@
           </div>
         </div>
       </div>
-      <div class="row">
-        <div class="col-xs-12" data-bind="visible: player.totalSpellSlots !== undefined">
+      <div class="row" data-bind="visible: isDM">
+        <div class="col-xs-12">
           Spell Slots
           <span class="text-muted pull-right">
             <small data-bind="text: currentSpellSlots()"></small> /
@@ -101,8 +101,8 @@
           </div>
         </div>
       </div>
-      <div class="row">
-        <div class="col-xs-12" data-bind="visible: player.totalTrackables !== undefined">
+      <div class="row" data-bind="visible: isDM">
+        <div class="col-xs-12">
           Features, Feats, and Traits
           <span class="text-muted pull-right">
             <small data-bind="text: currentTrackables()"></small> /
@@ -120,8 +120,8 @@
           </div>
         </div>
       </div>
-      <div class="row">
-        <div class="col-xs-12 col-padded" data-bind="visible: hasStats">
+      <div class="row" data-bind="visible: isDM">
+        <div class="col-xs-12 col-padded">
           <table class="table table-striped table-condensed">
             <tr>
               <th scope="row">Armor Class</th>

--- a/src/charactersheet/viewmodels/common/player_card/index.js
+++ b/src/charactersheet/viewmodels/common/player_card/index.js
@@ -94,6 +94,16 @@ export class PlayerCardViewModel extends ViewModel {
         this.isOnline() ? 'success' : 'failure'
     ));
 
+    hasStats = pureComputed(() => (
+        this.player.armorClass !== undefined
+        || this.player.hitDice !== undefined
+        || this.player.spellSaveDc !== undefined
+        || this.player.experience !== undefined
+        || this.player.passivePerception !== undefined
+        || this.player.passiveInvestigation !== undefined
+        || this.player.worthInGold !== undefined
+    ));
+
     popoverHtml() {
         if (!this.player.isActivePatron) {
             return '';

--- a/src/charactersheet/viewmodels/common/player_card/index.js
+++ b/src/charactersheet/viewmodels/common/player_card/index.js
@@ -117,8 +117,6 @@ export class PlayerCardViewModel extends ViewModel {
     }
 
     coreDidChange() {
-        this.party(null);
-
         const key = CoreManager.activeCore().type.name();
         this.playerType(PlayerTypes[key]);
     }

--- a/src/charactersheet/viewmodels/common/player_card/index.js
+++ b/src/charactersheet/viewmodels/common/player_card/index.js
@@ -3,7 +3,8 @@ import { capitalize } from 'lodash';
 import { observable, components, pureComputed } from 'knockout';
 import { ViewModel } from 'charactersheet/viewmodels/abstract';
 import { PartyService } from 'charactersheet/services/common';
-import { Notifications } from 'charactersheet/utilities';
+import { CoreManager, Notifications } from 'charactersheet/utilities';
+import { PlayerTypes } from 'charactersheet/models/common';
 import template from './index.html';
 import './index.css';
 
@@ -18,16 +19,22 @@ export class PlayerCardViewModel extends ViewModel {
         this.isOnline = observable(
             PartyService.playerIsOnline(this.player.uuid)
         );
+        const key = CoreManager.activeCore().type.name();
+        this.playerType = observable(key);
     }
 
     setUpSubscriptions() {
         super.setUpSubscriptions();
 
-        const partyDidChange = Notifications.party.changed.add(this.partyDidChange);
-        this.subscriptions.push(partyDidChange);
+        this.subscriptions.push(Notifications.coreManager.changed.add(this.coreDidChange));
+        this.subscriptions.push(Notifications.party.changed.add(this.partyDidChange));
     }
 
     // UI
+
+    isDM = pureComputed(() => (
+        PlayerTypes.dm.key === this.playerType()
+    ));
 
     currentMaxHp() {
         return this.player.maxHitPoints - this.player.maxHitPointsReductionDamage;
@@ -94,16 +101,6 @@ export class PlayerCardViewModel extends ViewModel {
         this.isOnline() ? 'success' : 'failure'
     ));
 
-    hasStats = pureComputed(() => (
-        this.player.armorClass !== undefined
-        || this.player.hitDice !== undefined
-        || this.player.spellSaveDc !== undefined
-        || this.player.experience !== undefined
-        || this.player.passivePerception !== undefined
-        || this.player.passiveInvestigation !== undefined
-        || this.player.worthInGold !== undefined
-    ));
-
     popoverHtml() {
         if (!this.player.isActivePatron) {
             return '';
@@ -117,6 +114,13 @@ export class PlayerCardViewModel extends ViewModel {
 
     partyDidChange() {
         this.isOnline(PartyService.playerIsOnline(this.player.uuid));
+    }
+
+    coreDidChange() {
+        this.party(null);
+
+        const key = CoreManager.activeCore().type.name();
+        this.playerType(PlayerTypes[key]);
     }
 }
 


### PR DESCRIPTION
### Summary of Changes

[This commit](https://github.com/adventurerscodex/adventurerscodex/commit/2a489b3ed2d44accdc8ab1d17d1aacdac4eedb9f) broke the layout of player cards for players in a party when it tried to fix the layout for DMs. This has apparently been in master for some time.

This PR now fixes this issue.

### Issues Fixed

None logged.

### Changes Proposed (if any)

N/A

### Screen Shot of Proposed Changes (if UI related)
<img width="362" alt="Screen Shot 2023-05-09 at 9 44 04 AM" src="https://github.com/adventurerscodex/adventurerscodex/assets/3310280/d9a8256c-81d7-46a5-b24f-65b57952d9e7">

 
<img width="342" alt="Screen Shot 2023-05-09 at 9 44 13 AM" src="https://github.com/adventurerscodex/adventurerscodex/assets/3310280/8e1a3d13-ad4c-468f-b115-c94aa5b6388a">

