### PR TITLE
Adds support for uploading Donjon export files to create encounters.

### DIFF
--- a/src/charactersheet/components/form-submit-actions.js
+++ b/src/charactersheet/components/form-submit-actions.js
@@ -31,6 +31,12 @@ export class FormSubmitActionComponent {
         this.addForm = params.addForm;
         this.showDisclaimer = params.showDisclaimer;
         this.reset = params.reset;
+        this.showSave = params.showSave || true;
+        this.submitTitle = params.submitTitle || (
+            ko.unwrap(this.addForm)
+            ? 'Add'
+            : 'Save'
+        );
         this.delete = params.delete;
     }
 
@@ -67,11 +73,8 @@ ko.components.register('form-submit-actions', {
           <button class="btn btn-sm btn-default"\
                   type="reset"\
                   data-bind="click: $component.clickReset">Cancel</button>\
-          <!-- ko ifnot: $component.addForm -->\
-          <button class="btn btn-sm btn-primary" type="submit">Save</button>\
-          <!-- /ko -->\
-          <!-- ko if: $component.addForm -->\
-          <button type="submit" class="btn btn-primary btn-sm">Add</button>\
+          <!-- ko if: $component.showSave -->\
+          <button class="btn btn-sm btn-primary" type="submit" data-bind="text: submitTitle"></button>\
           <!-- /ko -->\
         </div>\
       </div>\

--- a/src/charactersheet/utilities/index.js
+++ b/src/charactersheet/utilities/index.js
@@ -6,4 +6,4 @@ export { Notifications } from './notifications';
 export { TabFragmentManager } from './tab_fragment_manager';
 export { Utility } from './convenience';
 export { ViewModelUtilities } from './view_model_utilities';
-export uploadFile from './upload_file';
+export { uploadFile, uploadFormData } from './upload_file';

--- a/src/charactersheet/utilities/upload_file.js
+++ b/src/charactersheet/utilities/upload_file.js
@@ -8,11 +8,25 @@ import { PersistenceService } from 'charactersheet/services';
  * The optional progress handler returns a value of 1-100 whenever the
  * percent progress of the upload changes.
  */
-const uploadFile = (file, url, progressHandler=undefined) => (
+const uploadFile = (file, url, progressHandler=undefined) => {
+    let formData = new FormData();
+    formData.append('file', file);
+    return uploadFormData(formData, url, progressHandler);
+};
+
+
+
+/**
+ * Upload the given form data object to the endpoint at the given URL.
+ * Because files are handled differently from JSON APIs, we need to
+ * have a separate way to upload them than via Hypnos.
+ *
+ * The optional progress handler returns a value of 1-100 whenever the
+ * percent progress of the upload changes.
+ */
+const uploadFormData = (formData, url, progressHandler=undefined) => (
     new Promise((resolve, reject) => {
         let req = new XMLHttpRequest();
-        let formData = new FormData();
-        formData.append('file', file);
 
         if (!!progressHandler) {
             req.upload.addEventListener('progress', ({ loaded, total }) => {
@@ -43,3 +57,4 @@ const uploadFile = (file, url, progressHandler=undefined) => (
 );
 
 export default uploadFile;
+export { uploadFile, uploadFormData };

--- a/src/charactersheet/viewmodels/dm/encounter/import-form.html
+++ b/src/charactersheet/viewmodels/dm/encounter/import-form.html
@@ -1,0 +1,104 @@
+<form data-bind="submit: $component.submit">
+  <card-submit-actions params="{reset: $component.reset}"></card-submit-actions>
+  <!-- ko if: $component.addForm -->
+  <div class="h4 collapsable-card-title">
+    Import Encounter
+  </div>
+  <p class="text-muted">
+    <small>
+      Import a dungeon from
+      <a href="https://donjon.bin.sh/5e/dungeon/" title="donjon.bin.sh" target="_blank">
+        donjon.bin.sh</a>. Include the dungeon JSON file which can be downloaded
+      at the bottom of the page.
+    </small>
+  </p>
+  <!-- /ko -->
+  <div class="row" data-bind="with: entity">
+    <!-- ko ifnot: $component.isUploading -->
+    <div class="form-group col col-sm-12">
+      <label for="name" class="control-label">
+        Dungeon JSON File
+      </label>
+      <input
+        type="file"
+        name="dataFile"
+        accept="application/json,.json"
+        required
+        data-bind="event: { change: () => $component.dataFile($element.files[0]) }"
+      />
+    </div>
+    <div class="form-group col col-sm-12">
+      <label for="name" class="control-label">
+        Dungeon Map Image File <small class="text-muted">Optional</small>
+      </label>
+      <input
+        type="file"
+        name="mapImageFile"
+        accept=".png,.jpg,.jpeg"
+        data-bind="
+          event: { change: () => $component.mapImageFile($element.files[0]) },
+          enable: $component.isActivePatron() && $component.imagesRemaining() > 0
+        "
+      />
+    </div>
+    <!-- /ko -->
+    <!-- ko if: $component.isUploading -->
+    <div class="col col-sm-12">
+      <div class="bordered pt-2 pb-2 pl-2 pr-2 mb-2 rounded">
+        <div class="text-center text-muted mb-2">
+          <b>Uploading...</b>
+        </div>
+        <div data-bind="barProgress: {
+          data: {
+            value: $component.progress,
+            maxValue: 100
+          },
+          config: {
+            strokeWidth: 2,
+            trailWidth: 1,
+            svgStyle: {
+              display: 'block',
+              width: '100%',
+              minHeight: '5px',
+              maxHeight: '5px',
+            },
+            from: {
+              color: $component.barColor()
+            },
+            to: {
+              color: $component.barColor()
+            }
+          }
+        }"></div>
+      </div>
+    </div>
+    <!-- /ko -->
+    <!-- ko ifnot: $component.isActivePatron -->
+    <div class="col col-sm-12 alert alert-info">
+      <p>
+        Become a patron to upload images as part of your Donjon Import. <a
+        href="https://www.patreon.com/bePatron?u=5313385"
+        target="_blank"
+        rel="noreferrer"
+        title="Patreon"
+      >
+        Check out our Patreon page &#8594;
+      </a>
+      </p>
+    </div>
+    <!-- /ko -->
+    <!-- ko if: $component.isActivePatron() && $component.imagesRemaining() === 0 -->
+    <div class="col col-sm-12 alert alert-warning">
+      <p>
+        You have uploaded the maximum number of images for your current Patreon Tier.
+      </p>
+    </div>
+    <!-- /ko -->
+    <form-submit-actions params="{
+      reset: $component.reset,
+      delete: $component.delete,
+      addForm: $component.addForm,
+      submitTitle: 'Import',
+    }"></form-submit-actions>
+  </div>
+</form>

--- a/src/charactersheet/viewmodels/dm/encounter/import-form.html
+++ b/src/charactersheet/viewmodels/dm/encounter/import-form.html
@@ -1,5 +1,4 @@
 <form data-bind="submit: $component.submit">
-  <card-submit-actions params="{reset: $component.reset}"></card-submit-actions>
   <!-- ko if: $component.addForm -->
   <div class="h4 collapsable-card-title">
     Import Encounter
@@ -14,6 +13,21 @@
   </p>
   <!-- /ko -->
   <div class="row" data-bind="with: entity">
+    <!-- ko ifnot: $component.isActivePatron -->
+    <div class="col col-sm-12 alert alert-info">
+      <p>
+        Become a patron to import from Donjon. <a
+          href="https://www.patreon.com/bePatron?u=5313385"
+          target="_blank"
+          rel="noreferrer"
+          title="Patreon"
+        >
+          Check out our Patreon page &#8594;
+        </a>
+      </p>
+    </div>
+    <!-- /ko -->
+    <!-- ko if: $component.isActivePatron -->
     <!-- ko ifnot: $component.isUploading -->
     <div class="form-group col col-sm-12">
       <label for="name" class="control-label">
@@ -37,7 +51,7 @@
         accept=".png,.jpg,.jpeg"
         data-bind="
           event: { change: () => $component.mapImageFile($element.files[0]) },
-          enable: $component.isActivePatron() && $component.imagesRemaining() > 0
+          enable: $component.imagesRemaining() > 0
         "
       />
     </div>
@@ -73,32 +87,20 @@
       </div>
     </div>
     <!-- /ko -->
-    <!-- ko ifnot: $component.isActivePatron -->
-    <div class="col col-sm-12 alert alert-info">
-      <p>
-        Become a patron to upload images as part of your Donjon Import. <a
-        href="https://www.patreon.com/bePatron?u=5313385"
-        target="_blank"
-        rel="noreferrer"
-        title="Patreon"
-      >
-        Check out our Patreon page &#8594;
-      </a>
-      </p>
-    </div>
-    <!-- /ko -->
-    <!-- ko if: $component.isActivePatron() && $component.imagesRemaining() === 0 -->
+    <!-- ko if: $component.imagesRemaining() === 0 -->
     <div class="col col-sm-12 alert alert-warning">
       <p>
         You have uploaded the maximum number of images for your current Patreon Tier.
       </p>
     </div>
     <!-- /ko -->
+    <!-- /ko -->
     <form-submit-actions params="{
       reset: $component.reset,
       delete: $component.delete,
       addForm: $component.addForm,
       submitTitle: 'Import',
+      showSave: $component.isActivePatron,
     }"></form-submit-actions>
   </div>
 </form>

--- a/src/charactersheet/viewmodels/dm/encounter/import-form.js
+++ b/src/charactersheet/viewmodels/dm/encounter/import-form.js
@@ -1,0 +1,101 @@
+import { CoreManager, Notifications, uploadFormData, Fixtures } from 'charactersheet/utilities';
+import { AbstractChildFormModel } from 'charactersheet/viewmodels/abstract';
+import { Encounter, EncounterSection } from 'charactersheet/models/dm';
+import { UserServiceManager } from 'charactersheet/services';
+
+import autoBind from 'auto-bind';
+import ko from 'knockout';
+import template from './import-form.html';
+
+
+export class EncounterImportFormViewModel extends AbstractChildFormModel {
+
+    constructor(params) {
+        super(params);
+        autoBind(this);
+
+        this.forceCardResize = params.forceCardResize;
+    }
+
+    barColor = ko.observable(Fixtures.general.colorHexList[0]);
+    progress = ko.observable(0);
+    isUploading = ko.observable(false);
+
+    isActivePatron = ko.observable(false);
+    imagesRemaining = ko.observable(0);
+
+    mapImageFile = ko.observable();
+    dataFile = ko.observable();
+
+    modelClass() {
+        return Encounter;
+    }
+
+    setUpSubscriptions() {
+        super.setUpSubscriptions();
+
+        this.subscriptions.push(
+            Notifications.user.exists.add(this.userDidChange)
+        );
+        this.userDidChange();
+    }
+
+    async save() {
+        let success = true, error = null;
+
+        // The auto-camel-caser doesn't work on multi-part files. We need
+        // to use the actual snake-case for this.
+        let formData = new FormData();
+        formData.append('data_file', this.dataFile());
+        if (this.mapImageFile()) {
+            formData.append('map_image_file', this.mapImageFile());
+        }
+
+        // Use the Hypnos schema to get the import API URL.
+        const coreUuid = CoreManager.activeCore().uuid();
+        const url = schema.content.core.encounters.fromDonjon.url.replace(
+            '{coreUuid}',
+            coreUuid,
+        );
+
+        try {
+            this.isUploading(true);
+            const data = await uploadFormData(
+                formData,
+                url,
+                this.progress
+            );
+            const encounter = new Encounter();
+            encounter.importValues(data);
+            Notifications.encounter.added.dispatch(encounter);
+            this.isUploading(false);
+        } catch(e) {
+            success = false, error = e;
+        }
+        this.didSave(success, error);
+    }
+
+    didSave(success, error) {
+        super.didSave(success, error);
+
+        if (this.forceCardResize) {
+            this.forceCardResize();
+        }
+    }
+
+    // Events
+
+    userDidChange() {
+        const user = UserServiceManager.sharedService().user();
+        if (user) {
+            this.isActivePatron(user.isActivePatron);
+            this.imagesRemaining(user.remainingMediaUploads);
+        }
+    }
+}
+
+
+ko.components.register('encounter-import-form', {
+    viewModel: EncounterImportFormViewModel,
+    template: template
+});

--- a/src/charactersheet/viewmodels/dm/encounter/import-form.js
+++ b/src/charactersheet/viewmodels/dm/encounter/import-form.js
@@ -1,6 +1,6 @@
 import { CoreManager, Notifications, uploadFormData, Fixtures } from 'charactersheet/utilities';
 import { AbstractChildFormModel } from 'charactersheet/viewmodels/abstract';
-import { Encounter, EncounterSection } from 'charactersheet/models/dm';
+import { Encounter } from 'charactersheet/models/dm';
 import { UserServiceManager } from 'charactersheet/services';
 
 import autoBind from 'auto-bind';

--- a/src/charactersheet/viewmodels/dm/encounter/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter/index.js
@@ -3,6 +3,7 @@ import template from './index.html';
 import './edit';
 import './view';
 import './form';
+import './import-form';
 
 ko.components.register('encounter', {
     template: template

--- a/src/charactersheet/viewmodels/dm/encounter/view.html
+++ b/src/charactersheet/viewmodels/dm/encounter/view.html
@@ -18,6 +18,7 @@
     onselect: entity => {
       active(entity);
       column.push('encounter-detail', {encounter: active});
+      setTimeout($component.forceCardResize, 300);
     }"
   ></nested-list>
   <div class="mt-2 pt-2 border-top">
@@ -31,17 +32,45 @@
         }"
       ></encounter-form>
     </div>
+    <div id="import-donjon-encounter" class="collapse add-card">
+      <encounter-import-form
+        params="{
+          containerId: 'import-donjon-encounter',
+          show: $component.displayImportForm,
+          flip: $component.toggleShowImportForm,
+          forceCardResize: $component.forceCardResize,
+        }"
+      ></encounter-import-form>
+    </div>
     <!-- ko ifnot: $component.displayAddForm -->
-    <button
-      type="button"
-      class="btn btn-link btn-sm btn-block"
-      data-toggle="collapse"
-      data-target="#add-encounter"
-      data-bind="click: $component.toggleShowAddForm"
-    >
-      <i class="fa fa-plus"></i>
-      Add Encounter
-    </button>
+    <!-- ko ifnot: $component.displayImportForm -->
+    <div class="row">
+      <div class="col-xs-12 col-md-6">
+        <button
+          type="button"
+          class="btn btn-link btn-sm btn-block"
+          data-toggle="collapse"
+          data-target="#add-encounter"
+          data-bind="click: $component.toggleShowAddForm"
+        >
+          <i class="fa fa-plus"></i>
+          Add Encounter
+        </button>
+      </div>
+      <div class="col-xs-12 col-md-6">
+        <button
+          type="button"
+          class="btn btn-link btn-sm btn-block"
+          data-toggle="collapse"
+          data-target="#import-donjon-encounter"
+          data-bind="click: $component.toggleShowImportForm"
+        >
+          <i class="fa fa-upload"></i>
+          Import Encounter
+        </button>
+      </div>
+    </div>
+    <!-- /ko -->
     <!-- /ko -->
   </div>
   <!-- /ko -->

--- a/src/charactersheet/viewmodels/dm/encounter/view.js
+++ b/src/charactersheet/viewmodels/dm/encounter/view.js
@@ -14,11 +14,14 @@ class EncounterViewModel extends AbstractEncounterListViewModel {
         autoBind(this);
 
         this.addFormId = '#add-encounter';
+        this.importFormId = '#import-donjon-encounter';
         this.collapseAllId = '#encounter-pane';
         this.column = params.column;
         this.flip = params.flip;
         this.active = ko.observable();
         this.forceCardResize = params.forceCardResize;
+
+        this.displayImportForm = ko.observable(false);
     }
 
     async load() {
@@ -40,6 +43,22 @@ class EncounterViewModel extends AbstractEncounterListViewModel {
         // Pop off the children components so that there's
         // no legacy, deleted views displayed.
         this.column.popToRoot();
+    }
+
+    toggleShowAddForm() {
+        super.toggleShowAddForm();
+        setTimeout(this.forceCardResize, DELAY.LONG);
+    }
+
+    toggleShowImportForm() {
+        if (this.displayImportForm()) {
+            this.displayImportForm(false);
+            $(this.importFormId).collapse('hide');
+        } else {
+            this.displayImportForm(true);
+            $(this.importFormId).collapse('show');
+        }
+        setTimeout(this.forceCardResize, DELAY.LONG);
     }
 }
 

--- a/src/charactersheet/viewmodels/dm/encounter_sections/trap_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/trap_section/index.js
@@ -64,7 +64,6 @@ class TrapSectionViewModel extends AbstractEncounterTabularViewModel {
 
     async toggleArmed(trap, event) {
         event.stopPropagation();
-        console.log('armed', trap, event);
         trap.isActive(!trap.isActive());
         await trap.save();
     }

--- a/src/style/site.css
+++ b/src/style/site.css
@@ -637,9 +637,8 @@ ul.footer-icons li {
   overflow-y: auto;
 }
 
-.encounter-detail-place-holder {
-  height: 400px;
-  padding-top:175px;
+#encounter-pane {
+  min-height: 600px;
 }
 
 .notes-place-holder {


### PR DESCRIPTION
### Summary of Changes

Allows DMs to create full encounters using the export files generated by donjon.bin.sh. 

Patrons with image upload slots available are allowed to upload map images also exported by Donjon to their encounter. The image is uploaded once and bound to several sub-encounters as the environment image.

List of resources imported:

- Wandering Monsters
- Rooms
- Doors
- Treasure
- Monsters
- Read-aloud Text
- Environment Descriptions

### Issues Fixed

N/A

### Changes Proposed (if any)

N/A

### Screen Shot of Proposed Changes (if UI related)

<img width="1713" alt="Screenshot 2023-08-18 at 3 11 50 PM" src="https://github.com/adventurerscodex/adventurerscodex/assets/3310280/3243537a-8c7e-4d41-93c4-a3599c689293">
<img width="1713" alt="Screenshot 2023-08-18 at 3 12 09 PM" src="https://github.com/adventurerscodex/adventurerscodex/assets/3310280/32029b39-d2a5-433f-b7a3-55e8b75f1e94">
<img width="1713" alt="Screenshot 2023-08-18 at 3 12 25 PM" src="https://github.com/adventurerscodex/adventurerscodex/assets/3310280/fe69c258-0812-4796-b1e1-6d37f37e00bd">
<img width="1713" alt="Screenshot 2023-08-20 at 1 18 47 PM" src="https://github.com/adventurerscodex/adventurerscodex/assets/3310280/3404a643-58f0-4074-b34d-fcca223a0f02">
<img width="1713" alt="Screenshot 2023-08-20 at 1 19 05 PM" src="https://github.com/adventurerscodex/adventurerscodex/assets/3310280/05c9bcb7-2028-43f8-bbff-787d66c8ed02">
<img width="1713" alt="Screenshot 2023-08-20 at 1 19 15 PM" src="https://github.com/adventurerscodex/adventurerscodex/assets/3310280/bc73aaf2-a0d1-44d3-95fc-beb25a74e637">
<img width="1713" alt="Screenshot 2023-08-18 at 3 11 36 PM" src="https://github.com/adventurerscodex/adventurerscodex/assets/3310280/dfafeba7-6fa0-49bb-bd50-d1fe7e070390">
