### PR TITLE
Adds the ability for DMs to generate random weather for an encounter.

### DIFF
--- a/src/charactersheet/services/dm/index.js
+++ b/src/charactersheet/services/dm/index.js
@@ -1,0 +1,1 @@
+export { randomWeather } from './weather';

--- a/src/charactersheet/services/dm/weather.js
+++ b/src/charactersheet/services/dm/weather.js
@@ -1,4 +1,4 @@
-const MUNDANE_WEATHER = [
+const ALL_WEATHER = [
     'Light Wind',
     'Fog',
     'Hail',
@@ -26,9 +26,6 @@ const MUNDANE_WEATHER = [
     'Severe Thunderstorm',
     'Snowstorm',
     'Thunderstorm',
-];
-
-const ARCANE_WEATHER = [
     'Aberrant Sky',
     'Acid Rain',
     'Animus Blizzard',
@@ -58,16 +55,10 @@ const ARCANE_WEATHER = [
     'Whispering Wind',
 ];
 
-const ALL_WEATHER = [...MUNDANE_WEATHER, ...ARCANE_WEATHER];
-
 
 /**
- * Return a random description of the weather. Optionally this function
- * allows the user to specify weather that is arcane in nature or mundane.
+ * Return a random description of the weather.
  */
-export const randomWeather = (arcane=true) => {
-    if (!arcane) {
-        return MUNDANE_WEATHER[Math.floor(Math.random() * MUNDANE_WEATHER.length)];
-    }
+export const randomWeather = () => {
     return ALL_WEATHER[Math.floor(Math.random() * ALL_WEATHER.length)];
 }

--- a/src/charactersheet/services/dm/weather.js
+++ b/src/charactersheet/services/dm/weather.js
@@ -1,0 +1,73 @@
+const MUNDANE_WEATHER = [
+    'Light Wind',
+    'Fog',
+    'Hail',
+    'Heavy Snow',
+    'Rain',
+    'Sleet',
+    'Snow',
+    'Cold',
+    'Extreme Cold',
+    'Extreme Heat',
+    'Severe Cold',
+    'Severe Heat',
+    'Very Hot',
+    'Hurricane',
+    'Light Wind',
+    'Moderate Wind',
+    'Severe Wind',
+    'Strong Wind',
+    'Tornado',
+    'Windstorm',
+    'Blizzard',
+    'Duststorm',
+    'Greater Duststorm',
+    'Hurricane',
+    'Severe Thunderstorm',
+    'Snowstorm',
+    'Thunderstorm',
+];
+
+const ARCANE_WEATHER = [
+    'Aberrant Sky',
+    'Acid Rain',
+    'Animus Blizzard',
+    'Arcane Tempest',
+    'Blacksleet',
+    'Indigo Fog',
+    'Dire Hail',
+    'Draconic Clouds',
+    'Dragon\'s Breath',
+    'Ethereal Fog',
+    'Expeditious Tailwind',
+    'Firestorm',
+    'Gatestorm',
+    'Ghoststorm',
+    'Hallucinatory Stor',
+    'Immuring Sleet',
+    'Incendiary Clouds',
+    'Ghostly Wind',
+    'Luminous Clouds',
+    'Prismatic Rain',
+    'Skyquake',
+    'Solid Fog',
+    'Spiderweb Clouds',
+    'Starfall Hail',
+    'Temporal Wind',
+    'Thunder Hail',
+    'Whispering Wind',
+];
+
+const ALL_WEATHER = [...MUNDANE_WEATHER, ...ARCANE_WEATHER];
+
+
+/**
+ * Return a random description of the weather. Optionally this function
+ * allows the user to specify weather that is arcane in nature or mundane.
+ */
+export const randomWeather = (arcane=true) => {
+    if (!arcane) {
+        return MUNDANE_WEATHER[Math.floor(Math.random() * MUNDANE_WEATHER.length)];
+    }
+    return ALL_WEATHER[Math.floor(Math.random() * ALL_WEATHER.length)];
+}

--- a/src/charactersheet/services/index.js
+++ b/src/charactersheet/services/index.js
@@ -1,2 +1,3 @@
 export * from './character';
 export * from './common';
+export * from './dm';

--- a/src/charactersheet/viewmodels/dm/encounter_sections/environment_section/form.html
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/environment_section/form.html
@@ -37,10 +37,21 @@
     </div>
     <div class="form-group col-xs-12 col-md-6">
       <label>Weather</label>
-      <input type="text"
-             class="form-control"
-             name="weather"
-             data-bind="value: weather">
+      <div class="input-group">
+        <input type="text"
+           class="form-control"
+           name="weather"
+           data-bind="value: weather">
+        <span class="input-group-btn">
+          <button
+            class="btn btn-info btn-sm"
+            type="button"
+            data-bind="click: $component.setRandomWeather"
+          >
+            <i class="fa fa-random" aria-hidden="true"></i>
+          </button>
+        </span>
+      </div>
     </div>
     <div class="form-group col-xs-12 col-md-6">
       <label>Terrain</label>

--- a/src/charactersheet/viewmodels/dm/encounter_sections/environment_section/form.html
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/environment_section/form.html
@@ -47,6 +47,7 @@
             class="btn btn-info btn-sm"
             type="button"
             data-bind="click: $component.setRandomWeather"
+            title="Generate Random Weather"
           >
             <i class="fa fa-random" aria-hidden="true"></i>
           </button>

--- a/src/charactersheet/viewmodels/dm/encounter_sections/environment_section/form.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/environment_section/form.js
@@ -6,7 +6,7 @@ import {
     Utility
 } from 'charactersheet/utilities';
 import { AbstractEncounterFormViewModel } from 'charactersheet/viewmodels/abstract';
-import { PartyService } from 'charactersheet/services';
+import { PartyService, randomWeather } from 'charactersheet/services';
 import { Environment } from 'charactersheet/models/dm';
 import ko from 'knockout';
 import { get } from 'lodash';
@@ -38,6 +38,10 @@ class EnvironmentFormViewModel extends AbstractEncounterFormViewModel {
         const index = Fixtures.encounter.sections.environment.index;
         return this.encounter().sections()[index].tagline();
     });
+
+    setRandomWeather() {
+        this.entity().weather(randomWeather());
+    }
 }
 
 ko.components.register('environment-form', {


### PR DESCRIPTION
### Summary of Changes

Adds a new button in the DM tools that sets the weather of the current environment to a random weather.

This change also introduces a new minor service function that allows for additional (currently unused) functionality.

The Weather in the generator comes from the items available on this page: https://donjon.bin.sh/d20/weather/ Though I have removed some and tweaked others.

### Issues Fixed

N/A

### Changes Proposed (if any)

N/A

### Screen Shot of Proposed Changes (if UI related)

<img width="844" alt="Screenshot 2023-08-20 at 10 43 26 PM" src="https://github.com/adventurerscodex/adventurerscodex/assets/3310280/f84f8439-29d4-4e1b-a2f4-282c4d7de649">

