### PR TITLE
Adds new backend service for Random first/last Name Generation

### DIFF
--- a/src/charactersheet/services/common/index.js
+++ b/src/charactersheet/services/common/index.js
@@ -6,3 +6,4 @@ export { SortService } from './sort_service.js';
 export { StatusService } from './status_service.js';
 export { RandomNumberGeneratorService } from './rng_service.js';
 export * from './account';
+export * from './names';

--- a/src/charactersheet/services/common/names.js
+++ b/src/charactersheet/services/common/names.js
@@ -1,0 +1,161 @@
+import { DataRepository } from  'charactersheet/utilities';
+
+// Modification Notes:
+// This code has been slightly modified to fit both the AC style
+// and the needs of our systems. However it is 98% the same as the
+// original that can be found here:
+//
+// http://donjon.bin.sh/code/name/name_generator.js
+
+let chain_cache = {};
+
+
+export function generate_name(type) {
+    let chain;
+    if (chain = markov_chain(type)) {
+        return markov_name(chain);
+    }
+    return '';
+}
+
+
+function name_list(type, n_of) {
+    let list = [];
+
+    let i;
+    for (i = 0; i < n_of; i++) {
+        list.push(generate_name(type));
+    }
+    return list;
+}
+
+
+function markov_chain(type) {
+    let chain;
+    if (chain = chain_cache[type]) {
+        return chain;
+    } else {
+        let list;
+        if ((list = DataRepository.names[type]) && list.length) {
+            let chain;
+            if (chain = construct_chain(list)) {
+                chain_cache[type] = chain;
+                return chain;
+            }
+        }
+    }
+    return false;
+}
+
+
+
+function construct_chain(list) {
+    let chain = {};
+
+    let i;
+    for (i = 0; i < list.length; i++) {
+        let names = list[i].split(/\s+/);
+        chain = incr_chain(chain,'parts',names.length);
+
+        let j;
+        for (j = 0; j < names.length; j++) {
+            let name = names[j];
+            chain = incr_chain(chain,'name_len',name.length);
+
+            let c = name.substr(0,1);
+            chain = incr_chain(chain,'initial',c);
+
+            let string = name.substr(1);
+            let last_c = c;
+
+            while (string.length > 0) {
+                let c = string.substr(0,1);
+                chain = incr_chain(chain,last_c,c);
+
+                string = string.substr(1);
+                last_c = c;
+            }
+        }
+    }
+    return scale_chain(chain);
+}
+
+
+function incr_chain(chain, key, token) {
+    if (chain[key]) {
+        if (chain[key][token]) {
+            chain[key][token]++;
+        } else {
+            chain[key][token] = 1;
+        }
+    } else {
+        chain[key] = {};
+        chain[key][token] = 1;
+    }
+    return chain;
+}
+
+
+function scale_chain(chain) {
+    let table_len = {};
+    Object.keys(chain).forEach(key => {
+        table_len[key] = 0;
+
+        Object.keys(chain[key]).forEach(token => {
+            let count = chain[key][token];
+            let weighted = Math.floor(Math.pow(count,1.3));
+
+            chain[key][token] = weighted;
+            table_len[key] += weighted;
+        });
+    });
+    chain['table_len'] = table_len;
+    return chain;
+}
+
+
+function markov_name(chain) {
+    let parts = select_link(chain,'parts');
+    let names = [];
+
+    let i;
+    for (i = 0; i < parts; i++) {
+        let name_len = select_link(chain,'name_len');
+        let c = select_link(chain,'initial');
+        let name = c;
+        let last_c = c;
+
+        while (name.length < name_len) {
+            c = select_link(chain,last_c);
+            if (! c) {
+                break
+            };
+
+            name += c;
+            last_c = c;
+        }
+        names.push(name);
+    }
+    return names.join(' ');
+}
+
+
+function select_link(chain, key) {
+    let len = chain['table_len'][key];
+    if (! len) {
+        return false
+    };
+    let idx = Math.floor(Math.random() * len);
+    let tokens = Object.keys(chain[key]);
+    let acc = 0;
+
+    let i;
+    for (i = 0; i < tokens.length; i++) {
+        let token = tokens[i];
+        acc += chain[key][token];
+        if (acc > idx) {
+            return token
+        };
+    }
+    return false;
+}

--- a/src/charactersheet/settings.js
+++ b/src/charactersheet/settings.js
@@ -97,6 +97,9 @@ export var Settings = {
         }, {
             key: 'traps',
             url: 'https://adventurerscodex.com/data/v2/SRD/traps.min.json'
+        }, {
+            key: 'names',
+            url: 'https://adventurerscodex.com/data/misc/names.json'
         }
     ]
 };

--- a/src/charactersheet/viewmodels/dm/encounter_sections/npc_section/form.html
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/npc_section/form.html
@@ -6,18 +6,28 @@
   <div class="row">
     <div class="form-group col-xs-12">
       <label>Name<i class="required"></i></label>
-      <input
-        type="text"
-        class="form-control"
-        name="name"
-        placeholder="Khidell the Ferryman"
-        data-bind="
-          textInput: name,
-          hasFocus: $component.formElementHasFocus,
-          event: { blur: $component.reviewInput, invalid: $component.invalidate },
-          attr: { ...$component.validation.name },
-        "
-      />
+      <div class="input-group input-group-sm">
+        <input
+          type="text"
+          class="form-control"
+          name="name"
+          placeholder="Khidell the Ferryman"
+          data-bind="
+            textInput: name,
+            hasFocus: $component.formElementHasFocus,
+            event: { blur: $component.reviewInput, invalid: $component.invalidate },
+            attr: { ...$component.validation.name },
+          "
+        />
+        <div class="input-group-btn">
+          <button
+            class="btn btn-sm btn-info"
+            data-bind="click: $component.generateRandomName"
+          >
+            <i class="fa fa-random"></i>
+          </button>
+        </div>
+      </div>
     </div>
     <div class="form-group col-xs-12">
       <label>Race</i></label>

--- a/src/charactersheet/viewmodels/dm/encounter_sections/npc_section/form.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/npc_section/form.js
@@ -5,6 +5,7 @@ import { NPC } from 'charactersheet/models/dm';
 import ko from 'knockout';
 import template from './form.html';
 import { SELECTDATA } from 'charactersheet/constants';
+import { generate_name } from 'charactersheet/services/common';
 
 
 class NPCFormViewModel extends AbstractChildEncounterFormModel {
@@ -16,6 +17,12 @@ class NPCFormViewModel extends AbstractChildEncounterFormModel {
 
     modelClass() {
         return NPC;
+    }
+
+    generateRandomName() {
+        const firstName = generate_name('firstName');
+        const lastName = generate_name('lastName');
+        this.entity().name(`${firstName} ${lastName}`);
     }
 }
 


### PR DESCRIPTION
### Summary of Changes

This service is based on code from Donjon and uses a Markov Chain to generate realistic-ish names based on a list of sample names.

The seed data is pulled in via the DataRepository and this PR depends on that change.

This change only so far affects the NPC module of the DM tools as the New Character Wizard is under construction. This feature can be trivially added to that module at a later date to enable random PC names.

This change requires no API changes, only the Data Repository additions (other PR).

### Issues Fixed

N/a

### Changes Proposed (if any)

N/A

### Screen Shot of Proposed Changes (if UI related)

<img width="1265" alt="Screenshot 2023-08-27 at 4 04 06 PM" src="https://github.com/adventurerscodex/adventurerscodex/assets/3310280/bda9cc1e-bc64-4eb4-abc9-3046723a2dae">
