### PR TITLE
Deleting a note now requires confirmation through a browser confrmation dialog box

### DIFF
--- a/src/charactersheet/viewmodels/common/notes/form.html
+++ b/src/charactersheet/viewmodels/common/notes/form.html
@@ -32,7 +32,7 @@
     </div>
     <form-submit-actions params="{
         reset: $component.reset,
-        delete: $component.delete,
+        delete: $component.confirmDelete,
         addForm: $component.addForm
       }"></form-submit-actions>
   </div>

--- a/src/charactersheet/viewmodels/common/notes/form.js
+++ b/src/charactersheet/viewmodels/common/notes/form.js
@@ -5,6 +5,13 @@ import autoBind from 'auto-bind';
 import ko from 'knockout';
 import template from './form.html';
 
+const DELETE_CONFIRM_MESSAGE = `You are About to Delete a Note.
+
+
+This will permanently delete all data associated with this note. This action cannot be undone.
+
+Click Ok to delete this Note.`;
+
 export class NotesFormViewModel extends AbstractChildFormModel {
     constructor(params) {
         super(params);
@@ -20,6 +27,12 @@ export class NotesFormViewModel extends AbstractChildFormModel {
             this.entity().updateTitleFromHeadline();
         }
         await super.save();
+    }
+
+    async confirmDelete() {
+        if (confirm(DELETE_CONFIRM_MESSAGE)) {
+            await this.delete();
+        }
     }
 
     validation = {


### PR DESCRIPTION
### Summary of Changes

We got a feature request to implement confirmation on deleting a note. 

### Issues Fixed

None logged

### Changes Proposed (if any)

N/A

### Screen Shot of Proposed Changes (if UI related)


<img width="1665" alt="Screenshot 2023-09-01 at 11 30 51 AM" src="https://github.com/adventurerscodex/adventurerscodex/assets/3310280/d80e728e-1e1e-46a8-bdcd-7158f8a4de8c">
