### PR TITLE
Adjusts the build to use the package lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ ENV WS_URL ${WS_URL}
 
 # Copy in the dependencies first so Docker can cache them
 COPY package.json .
+COPY package-lock.json .
 RUN npm install
 
 # Build the project


### PR DESCRIPTION
### Summary of Changes

Docker build now uses package lock. It always should have but it didn't.

### Issues Fixed

N/A

### Changes Proposed (if any)

N/A

### Screen Shot of Proposed Changes (if UI related)

N/A