### PR TITLE
Fixes issue with DMs unable to click 'New' and see Wizard.

### DIFF
--- a/src/charactersheet/viewmodels/dm/root/index.js
+++ b/src/charactersheet/viewmodels/dm/root/index.js
@@ -152,15 +152,12 @@ export function DMRootViewModel() {
         HotkeysService.registerHotkey('6', self.activateExhibitTab);
         HotkeysService.registerHotkey('7', self.activateInitiativeTrackerTab);
 
-        self.subscriptions.push(Notifications.dm.tabShouldChange.add(self._setActiveTab));
+        Notifications.dm.tabShouldChange.add(self._setActiveTab);
     };
 
     self.unload = () => {
         HotkeysService.flushHotkeys();
-
-        for (const subscription of self.subscriptions) {
-            subscription.dispose();
-        }
+        Notifications.dm.tabShouldChange.remove(self._setActiveTab);
     };
 
     //Private Methods


### PR DESCRIPTION
### Summary of Changes

Current version has a bug where DMs clicking the 'New' button in the toolbar does nothing because the app doesn't shut down correctly.

### Issues Fixed

See above.

### Changes Proposed (if any)

N/A

### Screen Shot of Proposed Changes (if UI related)

N/A
