### PR TITLE
Adds Bonuses Toggle to Initiative Tracker

### DIFF
--- a/src/charactersheet/viewmodels/dm/initiative-tracker/index.html
+++ b/src/charactersheet/viewmodels/dm/initiative-tracker/index.html
@@ -273,7 +273,12 @@
     <td class="col-xs-4 col-md-3 col-lg-2">
       <div
         class="d-flex"
-        style="gap: 0.3rem; align-content: center; align-items: center;"
+        style="
+          gap: 0.3rem;
+          align-content: center;
+          align-items: center;
+          justify-content: space-between;
+        "
       >
         <input
           type="number"

--- a/src/charactersheet/viewmodels/dm/initiative-tracker/index.html
+++ b/src/charactersheet/viewmodels/dm/initiative-tracker/index.html
@@ -35,22 +35,43 @@
       <table class="table table-responsive table-ac-bordered table-hover">
         <thead class="ac-table-header">
           <tr>
-            <th class="col-xs-7 col-md-8 col-lg-9">
-              <!-- ko if: state() === State.called -->
-              Participants (unsorted)
-              <!-- /ko -->
-              <!-- ko if: state() === State.started -->
-              Initiative Order
-              <!-- /ko -->
-            </th>
-            <th class="col-xs-4 col-md-3 col-lg-2 text-center">
-              <button
-                class="btn btn-xs btn-info"
-                data-bind="click: rollForInitiative, enable: canReRoll"
-                type="button"
-              >
-                Roll for Initiative
-              </button>
+            <th class="col-xs-11" colspan="2">
+              <div class="d-flex" style="width: 100%; justify-content: space-between;">
+                <div>
+                  <!-- ko if: state() === State.called -->
+                  Participants (unsorted)
+                  <!-- /ko -->
+                  <!-- ko if: state() === State.started -->
+                  Initiative Order
+                  <!-- /ko -->
+                </div>
+                <div class="text-right">
+                  <button
+                    class="btn btn-xs btn-default mr-1"
+                    data-bind="
+                      click: toggleIncludeBonuses,
+                      state() === State.called,
+                    "
+                    type="button"
+                  >
+                    <!-- ko if: includeBonuses -->
+                    <i class="fa fa-times-circle"></i>
+                    Exclude Bonuses
+                    <!-- /ko -->
+                    <!-- ko ifnot: includeBonuses -->
+                    <i class="fa fa-plus-circle"></i>
+                    Include Bonuses
+                    <!-- /ko -->
+                  </button>
+                  <button
+                    class="btn btn-xs btn-info"
+                    data-bind="click: rollForInitiative, enable: canReRoll"
+                    type="button"
+                  >
+                    Roll for Initiative
+                  </button>
+                </div>
+              </div>
             </th>
             <th class="col-xs-1 text-right">
               <a href="#" data-bind="click: collapseAll">
@@ -211,7 +232,7 @@
       id: `#initiative_row_${uuid}`
     }"
   >
-    <td>
+    <td class="col-xs-7 col-md-8 col-lg-9">
       <div
         class="d-flex"
         data-toggle="collapse"
@@ -249,7 +270,7 @@
         </div>
       </div>
     </td>
-    <td>
+    <td class="col-xs-4 col-md-3 col-lg-2">
       <div
         class="d-flex"
         style="gap: 0.3rem; align-content: center; align-items: center;"
@@ -260,6 +281,7 @@
           class="form-control"
           style="width: 6rem;"
         />
+        <!-- ko if: $component.includeBonuses -->
         &nbsp;+&nbsp;
         <span>
           <!-- ko if: $component.modifierFor($data) >= 0 -->
@@ -274,6 +296,7 @@
           data-bind="text: $component.totalInitiativeFor($data)"
           style="font-size: 16px;"
         ></b>
+        <!-- /ko -->
       </div>
     </td>
     <td class="col-xs-1 text-right">

--- a/src/charactersheet/viewmodels/dm/initiative-tracker/index.js
+++ b/src/charactersheet/viewmodels/dm/initiative-tracker/index.js
@@ -46,6 +46,7 @@ export class InitiativeTrackerViewModel extends AbstractTabularViewModel {
         this.currentTurn = observable(null);
         this.rounds = observable(1);
         this.exclusions = observableArray([]);
+        this.includeBonuses = observable(true);
     }
 
     refresh() {
@@ -123,7 +124,11 @@ export class InitiativeTrackerViewModel extends AbstractTabularViewModel {
 
     totalInitiativeFor(item) {
         const roll = parseInt(item.initiative()) || 0;
-        return roll + this.modifierFor(item);
+        if (this.includeBonuses()) {
+            return roll + this.modifierFor(item);
+        } else {
+            return roll;
+        }
     }
 
     isPlayer(participant) {
@@ -242,6 +247,10 @@ export class InitiativeTrackerViewModel extends AbstractTabularViewModel {
         this.order(this.order().filter(item => item.uuid() !== entry.uuid()));
         this.exclusions.push(entry);
         this.updateInitiativeIfNeeded(true);
+    }
+
+    toggleIncludeBonuses() {
+        this.includeBonuses(!this.includeBonuses());
     }
 
     // Data Methods


### PR DESCRIPTION
### Summary of Changes

DMs can now exclude the automatic bonus calculation if they need to instead enter full initiative values rather than just dice rolls.

This allows the DM to set whether they'd prefer to enter dice rolls or full initiative.


### Issues Fixed

N/A

### Changes Proposed (if any)

N/A

### Screen Shot of Proposed Changes (if UI related)

<img width="1214" alt="Screenshot 2023-09-22 at 2 57 43 PM" src="https://github.com/adventurerscodex/adventurerscodex/assets/3310280/c7689baf-697b-4898-a45b-0e2bb11718dc">
<img width="1222" alt="Screenshot 2023-09-22 at 2 58 44 PM" src="https://github.com/adventurerscodex/adventurerscodex/assets/3310280/3bb9e7d9-9acf-4c9a-ae1d-61b6912883b2">
