### PR TITLE
Fix total item cost using a wrong calculated value for containers whose own cost is not in GP

### DIFF
--- a/src/charactersheet/viewmodels/character/items/index.js
+++ b/src/charactersheet/viewmodels/character/items/index.js
@@ -43,7 +43,7 @@ export class ItemsViewModel extends AbstractTabularViewModel {
     }
 
     totalCost = ko.pureComputed(() => (
-        calculateTotalValue(this.entities(), 'totalCalculatedCost', null)
+        calculateTotalValue(this.entities(), 'totalCalculatedCost', null, null)
     ));
 
     totalWeight = ko.pureComputed(() => (


### PR DESCRIPTION
### Summary of Changes

This fixes containers whose own cost is not in GP causing the total value of all items to be calculated incorrectly - e.g. pouches, whose value is 5 SP, caused all their contained items to be summed up at 1/10 of their value.

BTW Since I cannot run the application locally, this is untested. It's such a small change that this shouldn't matter though. I would welcome a change to the setup that allows running it locally - otherwise you'll get very few PRs, especially for more complex bugs and features.
Edit: got it to run locally and tested this change, works as expected. Will also make a PR with the changes necessary to get it to run locally.

### Issues Fixed

Has not been reported yet, I just fixed it directly ;)

### Changes Proposed (if any)

-

### Screen Shot of Proposed Changes (if UI related)

-
