### PR TITLE
DM UI Now Reflows based on Image/Text Presence.

### DIFF
--- a/src/charactersheet/models/dm/encounter_sections/npc.js
+++ b/src/charactersheet/models/dm/encounter_sections/npc.js
@@ -19,7 +19,16 @@ export class NPC extends KOModel {
     ];
 
     static mapping = {
-        include: ['coreUuid', 'encounterUuid', 'name', 'race', 'sourceUrl', 'playerText', 'description', 'uuid']
+        include: [
+            'coreUuid',
+            'encounterUuid',
+            'name',
+            'race',
+            'sourceUrl',
+            'playerText',
+            'description',
+            'uuid',
+        ]
     };
 
     uuid = ko.observable();

--- a/src/charactersheet/models/dm/encounter_sections/point_of_interest.js
+++ b/src/charactersheet/models/dm/encounter_sections/point_of_interest.js
@@ -20,7 +20,15 @@ export class PointOfInterest extends KOModel {
     LONG_DESCRIPTION_MAX_LENGTH = 200;
 
     static mapping = {
-        include: ['coreUuid', 'encounterUuid', 'name', 'sourceUrl', 'playerText', 'description', 'uuid']
+        include: [
+            'coreUuid',
+            'encounterUuid',
+            'name',
+            'sourceUrl',
+            'playerText',
+            'description',
+            'uuid',
+        ]
     };
 
     coreUuid = ko.observable();

--- a/src/charactersheet/viewmodels/dm/encounter_sections/environment_section/view.html
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/environment_section/view.html
@@ -5,12 +5,13 @@
   <card-edit-actions params="{ flip: flip }"></card-edit-actions>
 </div>
 <hr class="ac-table-header">
-<div class="row pl-2">
-  <div class="col-xs-8">
+<div class="d-flex pl-2">
+  <div class="d-flex-6">
     <b>Weather:</b>&nbsp;<span data-bind="text: weatherLabel"></span><br>
     <b>Terrain:</b>&nbsp;<span data-bind="text: terrainLabel"></span>
   </div>
-  <div class="col-xs-4 text-right">
+  <!-- ko if: convertedImageLink -->
+  <div class="d-flex-6 text-right" data-bind="if: convertedImageLink">
     <!-- ko if: shouldShowExhibitButton -->
     <div class="text-center inline-block">
       <span style="font-weight: bold;">Exhibit</span><br>
@@ -30,6 +31,7 @@
     </div>
     <!-- /ko -->
   </div>
+  <!-- /ko -->
 </div>
 <hr data-bind="visible: shouldShowDividingMarker"/>
 
@@ -38,6 +40,7 @@
     data-bind="markdownPreview: entity().description"
     class="preview-modal-overflow-sm d-flex-1 pl-1"
   ></div>
+  <!-- ko if: convertedImageLink -->
   <div class="d-flex-1 text-right d-block">
     <img
       class="img-responsive img-rounded clickable embedded-image-right"
@@ -52,4 +55,5 @@
       </i></small>
     </div>
   </div>
+  <!-- /ko -->
 </div>

--- a/src/charactersheet/viewmodels/dm/encounter_sections/maps_and_images_section/view.html
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/maps_and_images_section/view.html
@@ -4,11 +4,13 @@
   </div>
   <div class="col-xs-12">
     <div class="d-flex">
-      <div class="hidden-xs hidden-sm d-flex-1" data-bind="visible: description">
+      <!-- ko if: description -->
+      <div class="hidden-xs hidden-sm d-flex-1">
         <label>Description</label>
         <div data-bind="markdownPreview: description"></div>
       </div>
-      <div class="d-flex-1 text-center ml-2" data-bind="visible: convertedDisplayUrl">
+      <!-- /ko -->
+      <div class="d-flex-1 text-center ml-2">
         <div class="d-block">
           <img
             data-bind="
@@ -26,7 +28,10 @@
       </div>
     </div>
   </div>
-  <div class="col-xs-12 visible-xs visible-sm hidden-md hidden-lg" data-bind="visible: description">
+  <div
+    class="col-xs-12 visible-xs visible-sm hidden-md hidden-lg"
+    data-bind="visible: description"
+  >
     <label>Description</label>
     <div data-bind="markdownPreview: description"></div>
   </div>

--- a/src/charactersheet/viewmodels/dm/encounter_sections/npc_section/view.html
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/npc_section/view.html
@@ -7,11 +7,14 @@
   </div>
   <div class="col-xs-12">
     <div class="d-flex">
-      <div class="hidden-xs hidden-sm d-flex-1" data-bind="visible: description">
+      <!-- ko if: description -->
+      <div class="hidden-xs hidden-sm d-flex-1">
         <label>Description</label>
         <div data-bind="markdownPreview: description"></div>
       </div>
-      <div class="d-flex-1 text-center ml-2" data-bind="visible: convertedDisplayUrl">
+      <!-- /ko -->
+      <!-- ko if: sourceUrl -->
+      <div class="d-flex-1 text-center ml-2">
         <div class="d-block">
           <img
             data-bind="
@@ -27,9 +30,13 @@
           </div>
         </div>
       </div>
+      <!-- /ko -->
     </div>
   </div>
-  <div class="col-xs-12 visible-xs visible-sm hidden-md hidden-lg" data-bind="visible: description">
+  <div
+    class="col-xs-12 visible-xs visible-sm hidden-md hidden-lg"
+    data-bind="visible: description"
+  >
     <label>Description</label>
     <div data-bind="markdownPreview: description"></div>
   </div>

--- a/src/charactersheet/viewmodels/dm/encounter_sections/point_of_interest_section/view.html
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/point_of_interest_section/view.html
@@ -8,11 +8,14 @@
   </div>
   <div class="col-xs-12">
     <div class="d-flex">
-      <div class="hidden-xs hidden-sm d-flex-1" data-bind="visible: description">
+      <!-- ko if: description -->
+      <div class="hidden-xs hidden-sm d-flex-1">
         <label>Description</label>
         <div data-bind="markdownPreview: description"></div>
       </div>
-      <div class="d-flex-1 text-center ml-2" data-bind="visible: convertedDisplayUrl">
+      <!-- /ko -->
+      <!-- ko if: sourceUrl -->
+      <div class="d-flex-1 text-center ml-2">
         <div class="d-block">
           <img
             data-bind="
@@ -28,9 +31,13 @@
           </div>
         </div>
       </div>
+      <!-- /ko -->
     </div>
   </div>
-  <div class="col-xs-12 visible-xs visible-sm hidden-md hidden-lg" data-bind="visible: description">
+  <div
+    class="col-xs-12 visible-xs visible-sm hidden-md hidden-lg"
+    data-bind="visible: description"
+  >
     <label>Description</label>
     <div data-bind="markdownPreview: description"></div>
   </div>

--- a/src/style/site.css
+++ b/src/style/site.css
@@ -648,7 +648,6 @@ ul.footer-icons li {
 }
 
 .preview-modal-overflow-sm {
-  max-height: 225px;
   overflow-y: auto;
 }
 


### PR DESCRIPTION

### Summary of Changes

This commit tweaks the DM sections UI to hide sections of the view cards if their data isn't present. Previously we showed placeholder text/images but that just takes up useful space and makes the cards hard to read on tablets.

### Issues Fixed

N/A

### Changes Proposed (if any)

N/A

### Screen Shot of Proposed Changes (if UI related)


<img width="835" alt="Screenshot 2024-01-15 at 2 17 09 PM" src="https://github.com/adventurerscodex/adventurerscodex/assets/3310280/2688b6f1-ee62-4c40-b604-9e0ff0314322">
<img width="827" alt="Screenshot 2024-01-15 at 2 17 22 PM" src="https://github.com/adventurerscodex/adventurerscodex/assets/3310280/5ad1437b-2252-43da-9b9d-e8076245ea47">
<img width="836" alt="Screenshot 2024-01-15 at 2 17 31 PM" src="https://github.com/adventurerscodex/adventurerscodex/assets/3310280/a3732a63-58e3-40ee-92aa-23a76b253877">
<img width="832" alt="Screenshot 2024-01-15 at 2 17 39 PM" src="https://github.com/adventurerscodex/adventurerscodex/assets/3310280/8ad52d09-1867-412b-bb08-262de4d432e2">

