### PR TITLE
Fixes a reported bug where skills addForm didn't clear properly

### DIFF
--- a/src/charactersheet/viewmodels/character/skills/addForm.js
+++ b/src/charactersheet/viewmodels/character/skills/addForm.js
@@ -46,6 +46,7 @@ export class SkillsAddFormViewModel extends AbstractChildFormModel {
     async submit() {
         await super.submit();
         this.flipOnSave();
+        await this.refresh();
     }
 
     proficiencyOptions = [


### PR DESCRIPTION
### Summary of Changes

Fixes an issue (reported via Reddit DM) that the Skills section add form didn't refresh properly when adding data so adding multiple skills required a page reload.

### Issues Fixed

From the report: 

> ...you cannot add multiple skills into the skill area without refreshing the page between each skill you add.

### Changes Proposed (if any)

None

### Screen Shot of Proposed Changes (if UI related)

None
