### PR TITLE
Adds new Fields to a Campaign

### DIFF
--- a/src/charactersheet/models/dm/campaign.js
+++ b/src/charactersheet/models/dm/campaign.js
@@ -17,6 +17,8 @@ export class Campaign extends KOModel {
 
     coreUuid = ko.observable(null);
     setting = ko.observable();
+    motif = ko.observable();
+    description = ko.observable();
     name = ko.observable();
     createdAt = ko.observable();
 
@@ -60,6 +62,12 @@ Campaign.validationConstraints = {
         },
         setting: {
             maxlength: 128
-        }
+        },
+        description: {
+            maxlength: 1000
+        },
+        motif: {
+            maxlength: 128
+        },
     }
 };

--- a/src/charactersheet/utilities/fixtures.js
+++ b/src/charactersheet/utilities/fixtures.js
@@ -447,6 +447,23 @@ export var Fixtures = {
             'Explorer\'s Pack',
             'Priest\'s Pack',
             'Scholar\'s  Pack'
+        ],
+
+        motifOptions: [
+            'Fantasy/Adventure',
+            'Noir/Mystery',
+            'Magic Punk',
+            'Modern/Urban',
+            ''
+
+
+        ],
+
+        settingOptions: [
+            'Forgotten Realms',
+            'Eberron',
+            'Homebrew',
+            'Other',
         ]
     },
     statusPhraseWordMap: {

--- a/src/charactersheet/utilities/fixtures.js
+++ b/src/charactersheet/utilities/fixtures.js
@@ -454,9 +454,6 @@ export var Fixtures = {
             'Noir/Mystery',
             'Magic Punk',
             'Modern/Urban',
-            ''
-
-
         ],
 
         settingOptions: [

--- a/src/charactersheet/viewmodels/common/wizard/index.html
+++ b/src/charactersheet/viewmodels/common/wizard/index.html
@@ -667,7 +667,7 @@
       </div>
     </div>
     <div class="form-group">
-      <label for="playerName" class="col-sm-2 control-label">
+      <label for="motif" class="col-sm-2 control-label">
         Motif
       </label>
       <div class="col-sm-10">
@@ -685,7 +685,7 @@
       </div>
     </div>
     <div class="form-group">
-      <label for="background" class="col-sm-2 control-label">
+      <label for="description" class="col-sm-2 control-label">
         Description
       </label>
       <div class="col-sm-10">

--- a/src/charactersheet/viewmodels/common/wizard/index.html
+++ b/src/charactersheet/viewmodels/common/wizard/index.html
@@ -656,7 +656,7 @@
         <input
           type="text"
           class="form-control"
-          id="motif"
+          id="setting"
           maxlength="128"
           placeholder="Where does this adventure take place?"
           data-bind="

--- a/src/charactersheet/viewmodels/common/wizard/index.html
+++ b/src/charactersheet/viewmodels/common/wizard/index.html
@@ -676,7 +676,7 @@
           class="form-control"
           id="motif"
           maxlength="128"
-          placeholder="Noir/Mystery/Adventure"
+          placeholder="What is the general atmosphere of the campaign?"
           data-bind="
             textInput: motif,
             autocomplete: { source: motifOptions, onselect: motif }

--- a/src/charactersheet/viewmodels/common/wizard/index.html
+++ b/src/charactersheet/viewmodels/common/wizard/index.html
@@ -624,7 +624,7 @@
           type="text"
           class="form-control"
           id="campaignName"
-          placeholder=""
+          placeholder="The Blight of Ages"
           data-bind="value: campaignName"
           required
         >
@@ -643,6 +643,62 @@
           data-bind="value: playerName"
           required
         >
+      </div>
+    </div>
+
+    <hr />
+
+    <div class="form-group">
+      <label for="playerName" class="col-sm-2 control-label">
+        Setting
+      </label>
+      <div class="col-sm-10">
+        <input
+          type="text"
+          class="form-control"
+          id="motif"
+          maxlength="128"
+          placeholder="Where does this adventure take place?"
+          data-bind="
+            textInput: setting,
+            autocomplete: { source: settingOptions, onselect: setting }
+          "
+        >
+      </div>
+    </div>
+    <div class="form-group">
+      <label for="playerName" class="col-sm-2 control-label">
+        Motif
+      </label>
+      <div class="col-sm-10">
+        <input
+          type="text"
+          class="form-control"
+          id="motif"
+          maxlength="128"
+          placeholder="Noir/Mystery/Adventure"
+          data-bind="
+            textInput: motif,
+            autocomplete: { source: motifOptions, onselect: motif }
+          "
+        >
+      </div>
+    </div>
+    <div class="form-group">
+      <label for="background" class="col-sm-2 control-label">
+        Description
+      </label>
+      <div class="col-sm-10">
+        <textarea
+          type="text"
+          class="form-control"
+          id="description"
+          data-bind="textInput: description"
+          rows="4"
+          maxlength="1000"
+          placeholder="What is the overarching goal of this campaign? Is it series of small adventurers, or a grand quest to save a kingdom? Are there any important themes you want to make use of during this game?
+          "
+        ></textarea>
       </div>
     </div>
     <div class="text-right">

--- a/src/charactersheet/viewmodels/common/wizard/index.html
+++ b/src/charactersheet/viewmodels/common/wizard/index.html
@@ -649,7 +649,7 @@
     <hr />
 
     <div class="form-group">
-      <label for="playerName" class="col-sm-2 control-label">
+      <label for="setting" class="col-sm-2 control-label">
         Setting
       </label>
       <div class="col-sm-10">

--- a/src/charactersheet/viewmodels/common/wizard/index.js
+++ b/src/charactersheet/viewmodels/common/wizard/index.js
@@ -98,6 +98,9 @@ export class WizardViewModel extends ViewModel {
 
         this.campaignName = ko.observable();
         this.playerName = ko.observable();
+        this.setting = ko.observable();
+        this.motif = ko.observable();
+        this.description = ko.observable();
 
         //Static Data
 
@@ -106,6 +109,8 @@ export class WizardViewModel extends ViewModel {
         this.alignmentOptions = Fixtures.profile.alignmentOptions;
         this.backgroundOptions = Fixtures.profile.backgroundOptions;
         this.backpackOptions = Fixtures.wizardProfile.backpackOptions;
+        this.motifOptions = Fixtures.wizardProfile.motifOptions;
+        this.settingOptions = Fixtures.wizardProfile.settingOptions;
     }
 
     setUpSubscriptions() {
@@ -264,6 +269,9 @@ export class WizardViewModel extends ViewModel {
             params: {
                 campaign: {
                     name: this.campaignName(),
+                    setting: this.setting(),
+                    motif: this.motif(),
+                    description: this.description(),
                 },
                 playerName: this.playerName(),
                 profileImage: { type: 'email' },

--- a/src/charactersheet/viewmodels/dm/dm_portrait/form.html
+++ b/src/charactersheet/viewmodels/dm/dm_portrait/form.html
@@ -39,6 +39,30 @@
                event: { blur: $component.reviewInput, invalid: $component.invalidate },
                attr: { ...$component.validation.Campaign.setting }">
     </div>
+    <div class="form-group col-xs-12 col-sm-6"
+        data-bind="with: campaign">
+      <label class="control-label">Motif</label>
+      <input class="form-control"
+          placeholder="Motif/Theme"
+          name="motif"
+          data-bind="value: motif,
+               event: { blur: $component.reviewInput, invalid: $component.invalidate },
+               attr: { ...$component.validation.Campaign.motif }">
+    </div>
+    <div class="form-group col-xs-12"
+        data-bind="with: campaign">
+      <label class="control-label">Description</label>
+      <textarea class="form-control"
+        placeholder="..."
+        rows="4"
+        name="description"
+        data-bind="
+          value: description,
+          event: { blur: $component.reviewInput, invalid: $component.invalidate },
+          attr: { ...$component.validation.Campaign.description }
+        "
+      ></textarea>
+    </div>
     <!-- ko with: entity -->
     <div class="col-xs-12">
       <div class="row">

--- a/src/charactersheet/viewmodels/dm/dm_portrait/view.html
+++ b/src/charactersheet/viewmodels/dm/dm_portrait/view.html
@@ -42,16 +42,33 @@
     </div>
     <div class="col-sm-10 col-xs-12 characters-player-name">
       <div class="row">
-        <div class="col-xs-12 col-md-12 text-center-xs text-left-sm" data-bind="with: campaign">
-          <h3>
-            <span id="nameLabel" data-bind="text: name" />
-            <small data-bind="with: $component.core">
-              by <span data-bind="text: playerName" />
-              <div data-bind="with: $component.campaign">
-                <span data-bind="text: setting" />
-              </div>
-            </small>
-          </h3>
+        <div class="col-xs-12 col-md-12 text-center-xs text-left-sm">
+          <div class="row" data-bind="with: $component.core">
+            <div class="col-xs-12 h3">
+              <span id="nameLabel" data-bind="text: $component.campaign().name"></span>
+              <!-- ko if: playerName -->
+              <small>by <span data-bind="text: playerName"></span></small>
+              <!-- /ko -->
+            </div>
+            <!-- ko with: $component.campaign -->
+            <div class="col-xs-12 col-sm-8">
+                <div>
+                  <span data-bind="text: setting" />
+                  <!-- ko if: motif -->
+                  (<span data-bind="text: motif" />)
+                  <!-- /ko -->
+                  <!-- ko if: description -->
+                  <hr class="mt-2 mb-1"/>
+                  <div
+                    style="font-size: small;"
+                    data-bind="text: description"
+                  ></div>
+                  <hr class="mt-1 mb-2"/>
+                  <!-- /ko -->
+                </div>
+            </div>
+            <!-- /ko -->
+          </div>
         </div>
         <div class="col-xs-12">
           <party-status-line></party-status-line>


### PR DESCRIPTION
### Summary of Changes

Adds fields to Camping (and DM Wizard) to better allow DMs to specify the time…/place/and theme of their games (and to provide overarching info when prompting GPT for suggestions.

These fields have two goals:

1. To provide a place for the DM to specify the setting of their campaign and also to provide a place for them to denote the themes. 
2. We can use these fields for suggestions (GPT or otherwise via pre-pop).

**Reminder** there is an API change needed for this.

### Issues Fixed

N/A

### Changes Proposed (if any)

N/A

### Screen Shot of Proposed Changes (if UI related)

<img width="1327" alt="Screenshot 2025-05-08 at 1 44 45 PM" src="https://github.com/user-attachments/assets/5b8563f3-70b4-49c7-80ab-ee776d3ad7ef" />
<img width="1641" alt="Screenshot 2025-05-08 at 1 45 26 PM" src="https://github.com/user-attachments/assets/2f7441d1-cc43-4392-b897-00be157428a3" />

