### PR TITLE
Adds Encounter Completion and Objective UI.

### DIFF
--- a/src/charactersheet/components/nested-list/cell.html
+++ b/src/charactersheet/components/nested-list/cell.html
@@ -30,7 +30,7 @@
     role="button"
     data-bind="with: entity, click: $component.select"
   >
-    <span data-bind="html: name"></span>
+    <span data-bind="html: cellContent"></span>
     <!-- ko if: $data.badge -->
     <span class="badge" style="float:none;" data-bind="text: badge"></span>
     <!-- /ko -->

--- a/src/charactersheet/models/dm/encounter.js
+++ b/src/charactersheet/models/dm/encounter.js
@@ -22,6 +22,9 @@ export class Encounter extends KOModel {
     location = ko.observable();
     sections = ko.observableArray([]);
     notes = ko.observable();
+    isComplete = ko.observable();
+    completedAt = ko.observable();
+    objective = ko.observable();
 
     //Collapse Properties
     isOpen = ko.observable(false);
@@ -34,11 +37,17 @@ export class Encounter extends KOModel {
 
     id = ko.pureComputed(() => (this.uuid()));
 
-    displayName = ko.pureComputed(function() {
-        if (!ko.unwrap(self.name)) {
-            return 'Untitled Encounter';
+    cellContent = ko.pureComputed(() => {
+        const suffix = (
+            this.isComplete()
+            ? '<i class="fa fa-check-circle-o ml-1"></i>'
+            : '<i class="fa fa-circle-o ml-1"></i>'
+        );
+
+        if (!ko.unwrap(this.name)) {
+            return `<div class="d-flex" style="justify-content: space-between"><span>Untitled Encounter</span> ${suffix}</div>`;
         }
-        return this.name();
+        return `<div class="d-flex" style="justify-content: space-between"><span>${this.name()}</span> ${suffix}</div>`;
     });
 
     toggleIsOpen = async () => {
@@ -49,6 +58,15 @@ export class Encounter extends KOModel {
 
     arrowIconClass = ko.pureComputed(() => (
         this.isOpen() ? 'fa fa-caret-down' : 'fa fa-caret-right'
+    ));
+
+    // Convert the timestamp to a human readable date string.
+    completedOn = ko.pureComputed(() => (
+        this.completedAt() ? new Date(this.completedAt()).toLocaleDateString() : ''
+    ));
+
+    hasObjective = ko.pureComputed(() => (
+        !!this.objective()
     ));
 
     /**
@@ -101,6 +119,12 @@ export class Encounter extends KOModel {
         await this.ps.delete();
         Notifications.encounter.deleted.dispatch(this);
     }
+
+    markAsComplete = async () => {
+        this.isComplete(true);
+        await this.save()
+    }
+
 }
 
 Encounter.validationConstraints = {
@@ -112,6 +136,10 @@ Encounter.validationConstraints = {
         location: {
             required: false,
             maxlength: 256
+        },
+        objective: {
+            required: false,
+            maxlength: 500
         }
     },
     rules: {
@@ -122,6 +150,10 @@ Encounter.validationConstraints = {
         location: {
             required: false,
             maxlength: 256
+        },
+        objective: {
+            required: false,
+            maxlength: 500
         }
     }
 };

--- a/src/charactersheet/viewmodels/dm/encounter/form.html
+++ b/src/charactersheet/viewmodels/dm/encounter/form.html
@@ -13,7 +13,7 @@
       <input
         type="text"
         class="form-control"
-        placeholder="Surprise!"
+        placeholder="A Three-Headed Quest"
         name="name"
         data-bind="
           value: name,
@@ -36,6 +36,21 @@
           value: location,
           event: { blur: $component.reviewInput, invalid: $component.invalidate },
           attr: { ...$component.validation.location }
+        "
+      />
+    </div>
+    <div class="form-group col col-sm-12">
+      <label for="encounter.location">
+        Goal
+      </label>
+      <input
+        type="text"
+        class="form-control"
+        placeholder="Find the sacred shrub"
+        data-bind="
+          value: objective,
+          event: { blur: $component.reviewInput, invalid: $component.invalidate },
+          attr: { ...$component.validation.objective },
         "
       />
     </div>

--- a/src/charactersheet/viewmodels/dm/encounter_detail/form.html
+++ b/src/charactersheet/viewmodels/dm/encounter_detail/form.html
@@ -39,6 +39,31 @@
         "
       />
     </div>
+    <div class="form-group">
+      <label for="encounter.location">
+        Goal
+      </label>
+      <input
+        type="text"
+        class="form-control"
+        data-bind="
+          value: objective,
+          event: { blur: $component.reviewInput, invalid: $component.invalidate },
+          attr: { ...$component.validation.objective },
+        "
+      />
+    </div>
+    <div class="form-group">
+      <input
+        type="checkbox"
+        class="mr-1"
+        id="encounter.complete"
+        data-bind="checked: isComplete"
+      />
+      <label for="encounter.complete">
+        Complete
+      </label>
+    </div>
     <hr />
     <div class="h4">
       Sections<br />

--- a/src/charactersheet/viewmodels/dm/encounter_detail/view.html
+++ b/src/charactersheet/viewmodels/dm/encounter_detail/view.html
@@ -13,6 +13,43 @@
 </div>
 <hr class="ac-table-header">
 <!-- Encounter tabs -->
+
+<div class="pl-3 pr-3" data-bind="with: encounter">
+  <small
+    class="d-block"
+    data-bind=""
+  >
+    <i class="fa fa-trophy mr-1"></i>
+    <!-- ko if: hasObjective -->
+    <span data-bind="text: objective"></span>
+    <!-- /ko -->
+    <!-- ko ifnot: hasObjective -->
+    <span class="text-muted">
+      Add a goal or objective for this encounter
+    </span>
+    <!-- /ko -->
+  </small>
+  <!-- ko if: isComplete -->
+  <small class="d-block">
+    <i class="fa fa-check-circle-o mr-1"></i>
+    Completed <span data-bind="text: completedOn"></span>
+  </small>
+  <!-- /ko -->
+  <!-- ko ifnot: isComplete -->
+  <button
+    class="btn btn-xs btn-primary text-center d-block mt-1"
+    style="width: 100%;"
+    data-bind="click: async () => await markAsComplete()"
+  >
+    <i class="fa fa-check-circle-o mr-1"></i>
+    Mark as Complete
+  </button>
+  <!-- /ko -->
+</div>
+
+<hr class="ac-table-header mt-2 mb-2" />
+
+<h4 class="ml-2">Sections</h4>
 <ul class="list-group master-list" role="tablist">
   <button
     class="list-group-item d-flex"


### PR DESCRIPTION
### Summary of Changes

Adds new UI and fields to allow DMs to track encounter goals and completion.

- Encounter goal: the overarching reason why the players are on this quest
- Complete: is the goal complete or have the players finished with this encounter

These are both useful for DMs at a glance and in planning *and* help us better prompt GPT.

**Requires API PR**

<img width="1644" alt="Screenshot 2025-05-08 at 4 07 15 PM" src="https://github.com/user-attachments/assets/2d118506-2f17-4114-ba53-385a37d58c2a" />
<img width="1626" alt="Screenshot 2025-05-08 at 4 07 54 PM" src="https://github.com/user-attachments/assets/9e82aea1-8d75-4faa-b143-b6e00c916e07" />
