### PR TITLE
Allows DMs to make share links to Campaign sharesheets

### DIFF
--- a/src/charactersheet/viewmodels/common/root/index.html
+++ b/src/charactersheet/viewmodels/common/root/index.html
@@ -57,7 +57,7 @@
                   href="#">
                 <i class="fa fa-address-card"></i>&nbsp;&nbsp;Characters &amp; Games </a>
             </li>
-            <!-- ko if: selectedCore() && selectedCore().type.name() != 'dm' -->
+            <!-- ko if: selectedCore() -->
             <li>
               <a data-bind="click: toggleShareModal"
                   href="#">


### PR DESCRIPTION
### Summary of Changes

Easiest PR ever. Requires backend PR

<img width="1721" height="1277" alt="Screenshot 2025-07-14 at 1 56 42 PM" src="https://github.com/user-attachments/assets/402f6d60-987e-4a6d-80c8-466eea4771d7" />
