### PR TITLE
Adds Share Sheet Settings

### DIFF
--- a/src/charactersheet/components/card-edit-actions.js
+++ b/src/charactersheet/components/card-edit-actions.js
@@ -1,5 +1,14 @@
 import ko from 'knockout';
 
+const ViewMode = {
+    // Show all fields in the UI
+    all: 'all',
+    // Show the UI as it would appear in the exhibit
+    exhibit: 'exhibit',
+    // Show the UI as it would appear in the player share-sheet.
+    player: 'player',
+};
+
 /**
  * card-edit-actions component
  *
@@ -14,18 +23,51 @@ import ko from 'knockout';
  *  }"></card-edit-actions>
  */
 export class CardEditActionComponent {
+
+    // Show the `next` value for the text.
+    modes = {
+        [ViewMode.all]: 'View as Exhibit',
+        [ViewMode.exhibit]: 'View as Player Mode',
+        [ViewMode.player]: 'View All',
+    };
+
     constructor(params) {
         this.flip = params.flip;
+        this.mode = params.mode;
     }
+
+    text = ko.pureComputed(() => this.modes[this.mode()]);
+
     clickFlip = () => {
         this.flip();
     }
+
+    clickToggleDisplayMode = () => {
+        if (!this.mode) { return; }
+
+        if (this.mode() === ViewMode.all) {
+            this.mode(ViewMode.exhibit);
+        } else if (this.mode() === ViewMode.exhibit) {
+            this.mode(ViewMode.player)
+        } else {
+            this.mode(ViewMode.all);
+        }
+    }
+
 }
 
 ko.components.register('card-edit-actions', {
     viewModel: CardEditActionComponent,
     template: '\
     <div class="btn-group edit-btn" role="group" aria-label="actionButtons">\
+      <!-- ko if: mode -->\
+      <button class="btn btn-link text-hover-only" data-bind="click: $component.clickToggleDisplayMode">\
+        <!-- ko if: text -->\
+        <span class="mr-1 text-muted" data-bind="text: text"></span>\
+        <!-- /ko -->\
+        <i class="fa fa-eye fa-color-hover-success fa-color fa-lg clickable" aria-hidden="true"></i>\
+      </button>\
+      <!-- /ko -->\
       <button class="btn btn-link" data-bind="click: $component.clickFlip">\
         <span class="fa fa-pencil-square-o fa-color-hover-success fa-color fa-lg clickable" aria-hidden="true"></span>\
       </button>\

--- a/src/charactersheet/models/common/share_key.js
+++ b/src/charactersheet/models/common/share_key.js
@@ -5,15 +5,24 @@ export class ShareKey extends KOModel {
     static __skeys__ = ['core', 'shareKeys'];
 
     static mapping = {
-        include: ['coreUuid']
+        include: ['coreUuid', 'password']
     };
 
     coreUuid = ko.observable(null);
     link = ko.observable(null);
+    accessMode = ko.observable('private');
+    dataMode = ko.observable('all');
+    password = ko.observable(null);
     createdAt = ko.observable(null);
 
     createdAtDisplay = ko.pureComputed(() => {
         var date = new Date(this.createdAt());
         return date.toLocaleDateString();
     });
+
+    save = async () => {
+        const response = await this.ps.save();
+        this.importValues(response.object.exportValues());
+        return response.object;
+    }
 }

--- a/src/charactersheet/models/common/share_key.js
+++ b/src/charactersheet/models/common/share_key.js
@@ -11,7 +11,7 @@ export class ShareKey extends KOModel {
     coreUuid = ko.observable(null);
     link = ko.observable(null);
     accessMode = ko.observable('private');
-    dataMode = ko.observable('all');
+    dataVisibilityMode = ko.observable('all');
     password = ko.observable(null);
     createdAt = ko.observable(null);
 

--- a/src/charactersheet/utilities/notifications.js
+++ b/src/charactersheet/utilities/notifications.js
@@ -295,6 +295,12 @@ export var Notifications = {
         changed: new Signal()
     },
 
+    sharekey: {
+        added: new Signal(),
+        changed: new Signal(),
+        deleted: new Signal()
+    },
+
     skill: {
         added: new Signal(),
         changed: new Signal(),

--- a/src/charactersheet/viewmodels/common/root/index.html
+++ b/src/charactersheet/viewmodels/common/root/index.html
@@ -57,7 +57,7 @@
                   href="#">
                 <i class="fa fa-address-card"></i>&nbsp;&nbsp;Characters &amp; Games </a>
             </li>
-            <!-- ko if: selectedCore() && selectedCore().type.name() != 'dm' -->
+            <!-- ko if: selectedCore() -->
             <li>
               <a data-bind="click: toggleShareModal"
                   href="#">

--- a/src/charactersheet/viewmodels/common/root/index.html
+++ b/src/charactersheet/viewmodels/common/root/index.html
@@ -167,7 +167,7 @@
     <!-- /ko -->
     <!-- Share Modal -->
     <!-- ko if: shareModalStatus -->
-    <share params="modalStatus: shareModalStatus"></share>
+    <share params="core: selectedCore, modalStatus: shareModalStatus"></share>
     <!-- /ko -->
   <!-- /ko -->
 </div>

--- a/src/charactersheet/viewmodels/common/root/index.html
+++ b/src/charactersheet/viewmodels/common/root/index.html
@@ -167,7 +167,7 @@
     <!-- /ko -->
     <!-- Share Modal -->
     <!-- ko if: shareModalStatus -->
-    <share params="core: selectedCore, modalStatus: shareModalStatus"></share>
+    <share params="core: selectedCore, modalStatus: shareModalStatus, userIsPatron: userIsPatron"></share>
     <!-- /ko -->
   <!-- /ko -->
 </div>

--- a/src/charactersheet/viewmodels/common/share/form.html
+++ b/src/charactersheet/viewmodels/common/share/form.html
@@ -75,8 +75,7 @@
     </div>
     <small>
       Include only data that can be shown to players.
-      This will only include information pertaining to encounters marked as complete
-      and data that can be pushed to the <span style="white-space: nowrap"><i class="fa fa-desktop"></i>&nbsp;Exhibit.</span>
+      This will only include information pertaining to encounters marked as complete and will include data that can be pushed to the <span style="white-space: nowrap"><i class="fa fa-desktop"></i>&nbsp;Exhibit</span> as well as the names of NPCs and Monsters. For a full list of what is shown, <a href="https://adventurerscodex.com/dm.html#sharing">check out this page</a>.
     </small>
     <!-- /ko -->
   </fieldset>

--- a/src/charactersheet/viewmodels/common/share/form.html
+++ b/src/charactersheet/viewmodels/common/share/form.html
@@ -1,0 +1,68 @@
+<h3 class="mt-0">
+  <i class="fa fa-gear"></i>&nbsp;
+  Share Link Settings
+</h3>
+<p class="text-muted">
+  The following settings apply only to this share link. Other links for this
+  character/campaign might have other settings.
+</p>
+<form class="form-horizontal" data-bind="submit: $component.submit, with: entity">
+  <h4 class="mb-0">Access</h4>
+  <div class="radio">
+    <label>
+      <input type="radio" name="accessMode" value="private" data-bind="checked: accessMode">
+      Private
+    </label>
+  </div>
+  <small>Anyone with the link can access.</small>
+  <div class="radio">
+    <label>
+      <input type="radio" name="accessMode" value="restricted" data-bind="checked: accessMode">
+      Restricted
+    </label>
+  </div>
+  <small>Anyone with the link <i>and the password</i> can access.</small>
+  <!-- ko if: accessMode() === 'restricted' && !hasPassword() -->
+  <input
+    type="password"
+    class="form-control mt-1"
+    required
+    placeholder="Password"
+    data-bind="value: password"
+  />
+  <!-- /ko -->
+  <!-- ko if: accessMode() === 'restricted' && hasPassword() -->
+  <input
+    type="password"
+    class="form-control mt-1"
+    placeholder="Change Password"
+    data-bind="value: password"
+  />
+  <!-- /ko -->
+  <!-- ko if: $component.core().type.name() === 'dm' -->
+  <h4 class="mb-0">Content</h4>
+  <div class="radio">
+    <label>
+      <input type="radio" name="dataVisibilityMode" value="all" data-bind="checked: dataVisibilityMode">
+      DM Mode
+    </label>
+  </div>
+  <small>Include all data. This is suitable for sharing outside your party.</small>
+  <div class="radio">
+    <label>
+      <input type="radio" name="dataVisibilityMode" value="player" data-bind="checked: dataVisibilityMode">
+      Player Mode
+    </label>
+  </div>
+  <small>
+    Include only data that can be shown to players.
+    This will only include information pertaining to encounters marked as complete
+    and data that can be pushed to the <span style="white-space: nowrap"><i class="fa fa-desktop"></i>&nbsp;Exhibit.</span>
+  </small>
+  <!-- /ko -->
+  <div class="text-right">
+    <button class="btn btn-sm btn-secondary">
+      <i class="fa fa-save"></i>&nbsp;Save
+    </button>
+  </div>
+</form>

--- a/src/charactersheet/viewmodels/common/share/form.html
+++ b/src/charactersheet/viewmodels/common/share/form.html
@@ -2,67 +2,89 @@
   <i class="fa fa-gear"></i>&nbsp;
   Share Link Settings
 </h3>
+<!-- ko if: $component.userIsPatron -->
 <p class="text-muted">
   The following settings apply only to this share link. Other links for this
   character/campaign might have other settings.
 </p>
+<!-- /ko -->
+<!-- ko ifnot: $component.userIsPatron -->
+<div class="dashed-border p-2 rounded text-center">
+  <div>
+    <b>Become a Patron to Customize Sharing Settings</b>
+  </div>
+  <a
+    href="https://www.patreon.com/bePatron?u=5313385"
+    target="_blank"
+    rel="noreferrer"
+    title="Patreon"
+  >
+    Check out our Patreon page &#8594;
+  </a>
+</div>
+<!-- /ko -->
+
 <form class="form-horizontal" data-bind="submit: $component.submit, with: entity">
   <h4 class="mb-0">Access</h4>
-  <div class="radio">
-    <label>
-      <input type="radio" name="accessMode" value="private" data-bind="checked: accessMode">
-      Private
-    </label>
-  </div>
-  <small>Anyone with the link can access.</small>
-  <div class="radio">
-    <label>
-      <input type="radio" name="accessMode" value="restricted" data-bind="checked: accessMode">
-      Restricted
-    </label>
-  </div>
-  <small>Anyone with the link <i>and the password</i> can access.</small>
-  <!-- ko if: accessMode() === 'restricted' && !hasPassword() -->
-  <input
-    type="password"
-    class="form-control mt-1"
-    required
-    placeholder="Password"
-    data-bind="value: password"
-  />
-  <!-- /ko -->
-  <!-- ko if: accessMode() === 'restricted' && hasPassword() -->
-  <input
-    type="password"
-    class="form-control mt-1"
-    placeholder="Change Password"
-    data-bind="value: password"
-  />
-  <!-- /ko -->
-  <!-- ko if: $component.core().type.name() === 'dm' -->
-  <h4 class="mb-0">Content</h4>
-  <div class="radio">
-    <label>
-      <input type="radio" name="dataVisibilityMode" value="all" data-bind="checked: dataVisibilityMode">
-      DM Mode
-    </label>
-  </div>
-  <small>Include all data. This is suitable for sharing outside your party.</small>
-  <div class="radio">
-    <label>
-      <input type="radio" name="dataVisibilityMode" value="player" data-bind="checked: dataVisibilityMode">
-      Player Mode
-    </label>
-  </div>
-  <small>
-    Include only data that can be shown to players.
-    This will only include information pertaining to encounters marked as complete
-    and data that can be pushed to the <span style="white-space: nowrap"><i class="fa fa-desktop"></i>&nbsp;Exhibit.</span>
-  </small>
-  <!-- /ko -->
+  <fieldset data-bind="attr: { disabled: !$component.userIsPatron() }">
+    <div class="radio">
+      <label>
+        <input type="radio" name="accessMode" value="private" data-bind="checked: accessMode">
+        Private
+      </label>
+    </div>
+    <small>Anyone with the link can access.</small>
+    <div class="radio">
+      <label>
+        <input type="radio" name="accessMode" value="restricted" data-bind="checked: accessMode">
+        Restricted
+      </label>
+    </div>
+    <small>Anyone with the link <i>and the password</i> can access.</small>
+    <!-- ko if: accessMode() === 'restricted' && !hasPassword() -->
+    <input
+      type="password"
+      class="form-control mt-1"
+      required
+      placeholder="Password"
+      data-bind="value: password"
+    />
+    <!-- /ko -->
+    <!-- ko if: accessMode() === 'restricted' && hasPassword() -->
+    <input
+      type="password"
+      class="form-control mt-1"
+      placeholder="Change Password"
+      data-bind="value: password"
+    />
+    <!-- /ko -->
+    <!-- ko if: $component.core().type.name() === 'dm' -->
+    <h4 class="mb-0">Content</h4>
+    <div class="radio">
+      <label>
+        <input type="radio" name="dataVisibilityMode" value="all" data-bind="checked: dataVisibilityMode">
+        DM Mode
+      </label>
+    </div>
+    <small>Include all data. This is suitable for sharing outside your party.</small>
+    <div class="radio">
+      <label>
+        <input type="radio" name="dataVisibilityMode" value="player" data-bind="checked: dataVisibilityMode">
+        Player Mode
+      </label>
+    </div>
+    <small>
+      Include only data that can be shown to players.
+      This will only include information pertaining to encounters marked as complete
+      and data that can be pushed to the <span style="white-space: nowrap"><i class="fa fa-desktop"></i>&nbsp;Exhibit.</span>
+    </small>
+    <!-- /ko -->
+  </fieldset>
+  <!-- ko if: $component.userIsPatron -->
   <div class="text-right">
     <button class="btn btn-sm btn-secondary">
       <i class="fa fa-save"></i>&nbsp;Save
     </button>
   </div>
+  <!-- /ko -->
 </form>

--- a/src/charactersheet/viewmodels/common/share/form.js
+++ b/src/charactersheet/viewmodels/common/share/form.js
@@ -11,6 +11,7 @@ export class ShareKeyFormViewModel extends AbstractChildFormModel {
         autoBind(this);
 
         this.core = params.core;
+        this.userIsPatron = params.userIsPatron;
     }
 
     modelClass () {

--- a/src/charactersheet/viewmodels/common/share/form.js
+++ b/src/charactersheet/viewmodels/common/share/form.js
@@ -1,0 +1,24 @@
+import { AbstractChildFormModel } from 'charactersheet/viewmodels/abstract';
+import { ShareKey } from 'charactersheet/models/common';
+
+import autoBind from 'auto-bind';
+import ko from 'knockout';
+import template from './form.html';
+
+export class ShareKeyFormViewModel extends AbstractChildFormModel {
+    constructor(params) {
+        super(params);
+        autoBind(this);
+
+        this.core = params.core;
+    }
+
+    modelClass () {
+        return ShareKey;
+    }
+}
+
+ko.components.register('sharekey-form', {
+    viewModel: ShareKeyFormViewModel,
+    template: template
+});

--- a/src/charactersheet/viewmodels/common/share/index.html
+++ b/src/charactersheet/viewmodels/common/share/index.html
@@ -1,46 +1,101 @@
-<div class="modal fade" id="shareModal" tabindex="-1" role="dialog"
-    aria-labelledby="shareModalLabel" data-bind="modal: {
-        open: modalStatus,
-        onclose: closeModal,
-        onopen: setupClipboard }">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content container-fluid">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                  <span aria-hidden="true">&times;</span>
-                </button>
-                <h4 class="modal-title" id="shareModalLabel" data-dismiss="modal">Share</h4>
-            </div>
-            <div class="modal-body">
-              <p>Share your character or campaign with other Adventurers using the provided link.</p>
-              <p>Multiple links can be created, each linking to this character or campaign. If you'd like to revoke access to your character or campaign, simply delete the link.</p>
+<div
+  class="modal fade"
+  id="shareModal"
+  tabindex="-1"
+  role="dialog"
+  aria-labelledby="shareModalLabel"
+  data-bind="modal: {
+    open: modalStatus,
+    onclose: closeModal,
+    onopen: setupClipboard
+  }"
+>
+  <div class="modal-dialog" role="document">
+    <div class="modal-content container-fluid">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <h4 class="modal-title" id="shareModalLabel" data-dismiss="modal">Share</h4>
+      </div>
+      <div class="modal-body">
+        <p>Share your character or campaign with other Adventurers using the provided link.</p>
+        <p>
+          Multiple links can be created, each linking to this character or campaign.
+          If you'd like to revoke access to your character or campaign, simply delete the link.
+        </p>
 
-              <!-- ko if: shareKeys().length > 0 -->
-              <div class="list-group" data-bind="foreach: shareKeys" style="max-height: 250px; overflow-y:auto;">
-                <button class="list-group-item text-left col-xs-12">
-                  <div class="col-xs-11 copy" style="text-overflow: ellipsis; overflow-x: hidden; white-space: nowrap;"
-                  data-bind="attr: { 'data-clipboard-text': link }" data-clipboard-action="copy">
-                    <span data-bind="text: link"></span><br/>
-                    <small class="text-muted">Created:
-                      <span data-bind="text: createdAtDisplay"></span>
-                    </small>
-                  </div>
-                  <div class="col-xs-1">
-                    <a data-bind="click: $parent.deleteLink" href="#">
-                      <i class="fa fa-trash-o fa-color-hover"></i>
-                    </a>
-                  </div>
+        <div class="list-group">
+          <!-- ko foreach: entities -->
+          <div class="list-group-item">
+            <div class="d-flex justify-content-start align-items-stretch" style="gap: 1rem;">
+              <div class="flex-1">
+                <button
+                  class="btn btn-sm btn-primary pl-3 pr-3"
+                  data-bind="attr: { 'data-clipboard-text': link }"
+                  data-clipboard-action="copy"
+                >
+                  <i class="fa fa-copy"></i>
+                  <span class="sr-only">Copy Link</span>
                 </button>
               </div>
-              <small>Tip: Click on the link to copy it to your clipboard.</small>
-              <!-- /ko -->
+              <div class="flex-1">
+                <button
+                  type="button"
+                  class="btn btn-sm btn-default pl-3 pr-3"
+                  data-toggle="collapse"
+                  aria-expanded="false"
+                  data-bind="
+                    attr: {
+                      'data-target': `#share-settings-${uuid()}`,
+                      'aria-controls': `share-settings-${uuid()}`,
+                    }
+                  "
+                >
+                  <i class="fa fa-gear"></i>
+                  <span class="sr-only">Share Settings</span>
+                </button>
+              </div>
+              <div class="flex-1 pl-2 pr-2" style="
+                overflow-x: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+                flex-grow: 1;
+              ">
+                <span class="mr-1">
+                  <i class="fa fa-link"></i>
+                </span>
+                <span data-bind="text: link"></span>
+                <span class="d-block text-muted">Created:
+                  <span data-bind="text: createdAtDisplay"></span>
+                </span>
+              </div>
+              <div class="flex-1">
+                <button
+                  class="btn btn-sm btn-link fa-color-hover"
+                  data-bind="click: () => $parent.deleteLink($data)"
+                >
+                  <i class="fa fa-trash-o"></i>
+                </button>
+              </div>
             </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-primary"
-                data-bind="click: createSharableLink">
-                Create Link
-              </button>
+          </div>
+          <div class="collapse" data-bind="attr: { id: `share-settings-${uuid()}` }">
+            <div class="well">
+              <sharekey-form params="{ data: $data, core: $component.core }">
             </div>
+          </div>
+          <!-- /ko -->
+          <a
+            role="button"
+            class="list-group-item list-group-item-primary text-center"
+            data-bind="click: $component.createSharableLink"
+          >
+            <i class="fa fa-plus"></i>&nbsp;
+            Create Link
+          </a>
         </div>
+      </div>
     </div>
+  </div>
 </div>

--- a/src/charactersheet/viewmodels/common/share/index.html
+++ b/src/charactersheet/viewmodels/common/share/index.html
@@ -82,7 +82,11 @@
           </div>
           <div class="collapse" data-bind="attr: { id: `share-settings-${uuid()}` }">
             <div class="well">
-              <sharekey-form params="{ data: $data, core: $component.core }">
+              <sharekey-form params="{
+                data: $data,
+                core: $component.core,
+                userIsPatron: $component.userIsPatron,
+               }">
             </div>
           </div>
           <!-- /ko -->

--- a/src/charactersheet/viewmodels/common/share/index.html
+++ b/src/charactersheet/viewmodels/common/share/index.html
@@ -31,7 +31,7 @@
             <div class="d-flex justify-content-start align-items-stretch" style="gap: 1rem;">
               <div class="flex-1">
                 <button
-                  class="btn btn-sm btn-primary pl-3 pr-3"
+                  class="btn btn-sm btn-primary pl-3 pr-3 copy"
                   data-bind="attr: { 'data-clipboard-text': link }"
                   data-clipboard-action="copy"
                 >

--- a/src/charactersheet/viewmodels/common/share/index.js
+++ b/src/charactersheet/viewmodels/common/share/index.js
@@ -30,7 +30,6 @@ export class ShareViewModel extends AbstractTabularViewModel {
     }
 
     setupClipboard() {
-        // Clipboard initialization.
         const clipboard = new Clipboard('.copy', {
             container: document.getElementById('shareModal')
         });

--- a/src/charactersheet/viewmodels/common/share/index.js
+++ b/src/charactersheet/viewmodels/common/share/index.js
@@ -17,6 +17,7 @@ export class ShareViewModel extends AbstractTabularViewModel {
         autoBind(this);
         this.modalStatus = params.modalStatus || ko.observable(false);
         this.core = params.core;
+        this.userIsPatron = params.userIsPatron;
     }
 
     closeModal() {

--- a/src/charactersheet/viewmodels/common/share/index.js
+++ b/src/charactersheet/viewmodels/common/share/index.js
@@ -18,6 +18,7 @@ export class ShareViewModel extends AbstractTabularViewModel {
         this.modalStatus = params.modalStatus || ko.observable(false);
         this.core = params.core;
         this.userIsPatron = params.userIsPatron;
+        this.setupClipboard();
     }
 
     closeModal() {

--- a/src/charactersheet/viewmodels/common/share/index.js
+++ b/src/charactersheet/viewmodels/common/share/index.js
@@ -1,33 +1,35 @@
+import Clipboard from 'clipboard';
+import { ShareKey } from 'charactersheet/models/common';
 import {
     CoreManager,
     Notifications
 } from 'charactersheet/utilities';
-import Clipboard from 'clipboard';
-import { ShareKey } from 'charactersheet/models/common';
+import { AbstractTabularViewModel } from 'charactersheet/viewmodels/abstract';
+
+import autoBind from 'auto-bind';
 import ko from 'knockout';
 import template from './index.html';
+import './form';
 
-export function ShareViewModel(params) {
-    var self = this;
+export class ShareViewModel extends AbstractTabularViewModel {
+    constructor(params) {
+        super(params);
+        autoBind(this);
+        this.modalStatus = params.modalStatus || ko.observable(false);
+        this.core = params.core;
+    }
 
-    self.shareKeys = ko.observableArray([]);
-    self.modalStatus = params.modalStatus || ko.observable(false);
-
-    self.load = async () => {
-        self.shareKeys(await self.getShareKeys());
+    closeModal() {
+        this.modalStatus(false);
     };
 
-    self.unload = function() {
-        self.modalStatus(false);
-    };
+    modelClass () {
+        return ShareKey;
+    }
 
-    self.closeModal = function() {
-        self.modalStatus(false);
-    };
-
-    self.setupClipboard = function() {
+    setupClipboard() {
         // Clipboard initialization.
-        var clipboard = new Clipboard('.copy', {
+        const clipboard = new Clipboard('.copy', {
             container: document.getElementById('shareModal')
         });
 
@@ -37,23 +39,19 @@ export function ShareViewModel(params) {
         });
     };
 
-    self.getShareKeys = async function() {
-        var key = CoreManager.activeCore().uuid();
-        const response = await ShareKey.ps.list({coreUuid: key});
-        return response.objects;
-    };
-
-    self.deleteLink = async function(link) {
+    deleteLink = async function(link) {
         await link.ps.delete();
-        self.shareKeys(await self.getShareKeys());
+        this.entities(this.entities().filter(({ uuid }) => (
+            ko.unwrap(uuid) !== ko.unwrap(link.uuid)
+        )));
     };
 
-    self.createSharableLink = async function() {
-        var key = CoreManager.activeCore().uuid();
+    async createSharableLink() {
+        const key = CoreManager.activeCore().uuid();
         let sharableKey = new ShareKey();
         sharableKey.coreUuid(key);
         const newKey = await sharableKey.ps.create();
-        self.shareKeys.push(newKey.object);
+        this.entities.push(newKey.object);
     };
 }
 

--- a/src/charactersheet/viewmodels/dm/encounter_sections/point_of_interest_section/index.html
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/point_of_interest_section/index.html
@@ -83,17 +83,19 @@
                   elementId: 'poi_list',
                   context: {
                     data: $data,
+                    viewMode: $component.viewMode,
                     encounter: $component.encounter,
                     fullScreen: $component.fullScreen,
                   }
                 }">
             <div class="front">
               <div>
-                <card-edit-actions params="{ flip: flip }"></card-edit-actions>
+                <card-edit-actions params="{ flip: flip, mode: context.viewMode }"></card-edit-actions>
               </div>
               <point-of-interest-view
                 params="
                   poi: context.data,
+                  viewMode: context.viewMode,
                   fullScreen: context.fullScreen,
                 "
               ></point-of-interest-view>

--- a/src/charactersheet/viewmodels/dm/encounter_sections/point_of_interest_section/index.js
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/point_of_interest_section/index.js
@@ -2,7 +2,6 @@ import autoBind from 'auto-bind';
 import {
     Fixtures,
     Notifications,
-    Utility
 } from 'charactersheet/utilities';
 import { AbstractEncounterTabularViewModel } from 'charactersheet/viewmodels/abstract';
 import { PartyService, SortService } from 'charactersheet/services/common';
@@ -27,6 +26,7 @@ class PointOfInterestSectionViewModel extends AbstractEncounterTabularViewModel 
     }
 
     fullScreen = ko.observable(false);
+    viewMode = ko.observable('all');
     shouldShowExhibitButton = ko.observable(!!PartyService.party);
 
     modelClass() {

--- a/src/charactersheet/viewmodels/dm/encounter_sections/point_of_interest_section/view.html
+++ b/src/charactersheet/viewmodels/dm/encounter_sections/point_of_interest_section/view.html
@@ -1,14 +1,21 @@
 <div class="row" data-bind="with: poi">
   <div class="col-xs-12">
+    <!-- ko if: $component.viewMode() !== 'exhibit' -->
     <h4 data-bind="text: name"></h4>
+    <!-- /ko -->
+    <!-- ko ifnot: $component.viewMode() !== 'exhibit' -->
+    <h4><!-- We need a blank header for the UI. -->&nbsp;</h4>
+    <!-- /ko -->
+    <!-- ko if: $component.viewMode() === 'all' -->
     <p class="text-muted" data-bind="visible: difficultyCheckValue() || difficultyCheckSkill()">
       DC <span data-bind="text: difficultyCheckValue"></span>&nbsp;
       <span data-bind="text: difficultyCheckSkill"></span>
     </p>
+    <!-- /ko -->
   </div>
   <div class="col-xs-12">
     <div class="d-flex">
-      <!-- ko if: description -->
+      <!-- ko if: description() && $component.viewMode() === 'all' -->
       <div class="hidden-xs hidden-sm d-flex-1">
         <label>Description</label>
         <div data-bind="markdownPreview: description"></div>
@@ -42,7 +49,9 @@
     <div data-bind="markdownPreview: description"></div>
   </div>
   <div class="col-xs-12" data-bind="visible: playerText">
+    <!-- ko if: description() && $component.viewMode() === 'all' -->
     <label>Read Aloud Text</label>
+    <!-- /ko -->
     <div data-bind="markdownPreview: playerText"></div>
   </div>
 </div>

--- a/src/style/site.css
+++ b/src/style/site.css
@@ -2506,6 +2506,14 @@ tr .panel {
   position: relative;
 }
 
+.text-hover-only span {
+  display: none;
+}
+
+.text-hover-only:hover span{
+  display: inline;
+}
+
 @keyframes pulse {
 	0% {
 		transform: scale(0.95);

--- a/src/style/site.css
+++ b/src/style/site.css
@@ -2250,6 +2250,10 @@ tr .panel {
   align-items: center;
 }
 
+.align-items-stretch {
+  align-items: stretch;
+}
+
 .pt-0 {
   padding-top: 0rem;
 }


### PR DESCRIPTION
Adds customizable share sheet settings that are configurable on a per-link basis. This requires an API change. I also rewrote the old-style share component with the new style view models.

This PR is pending the DM share sheets.

<img width="1590" height="1367" alt="Screenshot 2025-07-17 at 4 48 50 PM" src="https://github.com/user-attachments/assets/adf73521-b562-4ce9-907f-5b5f3ae17bc6" />
<img width="1590" height="1367" alt="Screenshot 2025-07-17 at 7 33 33 PM" src="https://github.com/user-attachments/assets/8d24ed1f-2c80-4ab9-8f85-ae87771e7dc6" />

