### PR TITLE
Campaign Header Image

### DIFF
--- a/src/charactersheet/components/image-picker.js
+++ b/src/charactersheet/components/image-picker.js
@@ -13,6 +13,7 @@ export function ImagePickerComponentViewModel(params) {
     self.cells = params.cells || ko.observableArray();
     self.selectedCells = params.selectedCells || ko.observableArray();
     self.multiselect = params.multiselect == undefined ? true: params.multiselect;
+    self.style = params.style === undefined ? 'circle': params.style;
 
     self.selectCell = function(cell) {
         if (self.selectedCells().indexOf(cell) == -1) {
@@ -32,12 +33,14 @@ export function ImagePickerComponentViewModel(params) {
      * Returns the correct active css for a given cell.
      */
     self.isActiveCSS = function(cell) {
+        const base = `img img-${ko.unwrap(self.style)} img-padded`;
+
         var selected = self.selectedCells();
         if (selected && selected.indexOf(cell) > -1) {
-            return 'active';
+            return 'active' + base;
         }
-        return '';
-    };
+        return base;
+    }
 
     // Clear the selected cells when the cells list changes.
     self.cells.subscribe(() => {
@@ -51,7 +54,7 @@ ko.components.register('image-picker', {
         <div data-bind="foreach: cells" class="row row-padded">\
           <div class="col-md-3 col-xs-6 text-center col-padded">\
             <img data-bind="attr: { src: image }, css: $parent.isActiveCSS($data), click: $parent.selectCell"\
-                width="80" height="80" class="img img-circle img-padded" /><br />\
+                width="80" height="80" style="height: 80px; width: 80px; object-fit: cover;" /><br />\
             <p class="text-muted" data-bind="text: name"></p>\
           </div>\
         </div>\

--- a/src/charactersheet/components/image-picker.js
+++ b/src/charactersheet/components/image-picker.js
@@ -33,7 +33,7 @@ export function ImagePickerComponentViewModel(params) {
      * Returns the correct active css for a given cell.
      */
     self.isActiveCSS = function(cell) {
-        const base = `img img-${ko.unwrap(self.style)} img-padded`;
+        const base = ` img img-${ko.unwrap(self.style)} img-padded`;
 
         var selected = self.selectedCells();
         if (selected && selected.indexOf(cell) > -1) {

--- a/src/charactersheet/models/dm/campaign.js
+++ b/src/charactersheet/models/dm/campaign.js
@@ -20,6 +20,7 @@ export class Campaign extends KOModel {
     motif = ko.observable();
     description = ko.observable();
     name = ko.observable();
+    headerImageUrl = ko.observable();
     createdAt = ko.observable();
 
     summary = function() {

--- a/src/charactersheet/utilities/fixtures.js
+++ b/src/charactersheet/utilities/fixtures.js
@@ -65,6 +65,56 @@ export var Fixtures = {
             image: 'https://app.adventurerscodex.com/images/sample-headshots/troll-head.png'
         }
     ],
+    defaultHeaderImages: [
+        {
+            name: '',
+            image: 'https://p.d20.photos/file/d20-photos/finalized-media/4f5a566a-122b-49bf-9ac3-4937708d822b-4f5a566a-122b-49bf-9ac3-4937708d822b_lg7a81.jpg'
+        },
+        {
+            name: '',
+            image: 'https://p.d20.photos/file/d20-photos/finalized-media/0f92476e-2a06-46e9-9c46-58474ca05d99-0f92476e-2a06-46e9-9c46-58474ca05d99_lgb65c.jpg'
+        },
+        {
+            name: '',
+            image: 'https://p.d20.photos/file/d20-photos/finalized-media/5ba7a985-f563-4470-bd61-b14795aa81f7-5ba7a985-f563-4470-bd61-b14795aa81f7_lg2f46.jpg'
+        },
+        {
+            name: '',
+            image: 'https://p.d20.photos/file/d20-photos/finalized-media/1a71a8ed-74fe-46f6-91f0-a2b62ae29fa6-1a71a8ed-74fe-46f6-91f0-a2b62ae29fa6_lg2142.jpg'
+        },
+        {
+            name: '',
+            image: 'https://p.d20.photos/file/d20-photos/finalized-media/1aa02929-2d43-423d-a529-018f27cd0d71-1aa02929-2d43-423d-a529-018f27cd0d71_lg64fa.jpg'
+        },
+        {
+            name: '',
+            image: 'https://p.d20.photos/file/d20-photos/finalized-media/6e153b6d-94e5-4232-8673-f914d31c0e49-6e153b6d-94e5-4232-8673-f914d31c0e49_lgd8dd.jpg'
+        },
+        {
+            name: '',
+            image: 'https://p.d20.photos/file/d20-photos/finalized-media/4458e08f-1694-440e-8e43-8d969d07ec52-4458e08f-1694-440e-8e43-8d969d07ec52_lg2ea5.jpg'
+        },
+        {
+            name: '',
+            image: 'https://p.d20.photos/file/d20-photos/finalized-media/b3e6e62d-653d-47ba-a224-f3476b94bdd5-b3e6e62d-653d-47ba-a224-f3476b94bdd5_lgcd0b.jpg'
+        },
+        {
+            name: '',
+            image: 'https://p.d20.photos/file/d20-photos/finalized-media/20097e1f-1490-48e4-9ecd-0585f6176a9a-20097e1f-1490-48e4-9ecd-0585f6176a9a_lgdd83.jpg'
+        },
+        {
+            name: '',
+            image: 'https://p.d20.photos/file/d20-photos/finalized-media/58a41894-afe2-4fbc-96fe-2fb7c0a98d58-58a41894-afe2-4fbc-96fe-2fb7c0a98d58_lg8831.jpg'
+        },
+        {
+            name: '',
+            image: 'https://p.d20.photos/file/d20-photos/finalized-media/56c62a9b-5342-4c53-b23f-0cac8843d2c6-56c62a9b-5342-4c53-b23f-0cac8843d2c6_lgc37a.jpg'
+        },
+        {
+            name: '',
+            image: 'https://p.d20.photos/file/d20-photos/finalized-media/05422d20-f39e-4e8f-a254-255281204f65-05422d20-f39e-4e8f-a254-255281204f65_lgce47.jpg'
+        },
+    ],
     general : {
         currencyDenominationList : [
             'PP', 'GP', 'SP', 'EP', 'CP'],

--- a/src/charactersheet/viewmodels/character/ability_scores/form.html
+++ b/src/charactersheet/viewmodels/character/ability_scores/form.html
@@ -1,7 +1,7 @@
 <form class="form-horizontal"
     data-bind="{submit: $component.submit}">
   <card-submit-actions params="{reset: $component.reset}"></card-submit-actions>
-  <div class="h4 card-title"> Abilities &amp;<br />Saving Throws </div>
+  <div class="h4 card-title mt-0"> Abilities &amp;<br />Saving Throws </div>
   <div class="btn-group btn-group-justified"
       role="group"
       aria-label="Toggle Ability Score/Saving Throws">

--- a/src/charactersheet/viewmodels/character/ability_scores/view.html
+++ b/src/charactersheet/viewmodels/character/ability_scores/view.html
@@ -1,5 +1,5 @@
 <card-edit-actions params="{ flip: $parent.flip }"></card-edit-actions>
-<div class="h4 card-title">
+<div class="h4 card-title mt-0">
   Abilities &amp; Saving Throws
 </div>
 <table class="table table-responsive table-ac-bordered table-hover ac-table-data-cell score-save-table">

--- a/src/charactersheet/viewmodels/character/character_portrait/form.html
+++ b/src/charactersheet/viewmodels/character/character_portrait/form.html
@@ -1,5 +1,5 @@
 <form data-bind="{ submit: $component.submit }">
-  <div class="h4 card-title"> Name&nbsp;&amp; Portrait </div>
+  <div class="h4 card-title mt-0"> Name&nbsp;&amp; Portrait </div>
   <!-- ko ifnot: loaded(), completeOn: 'render' -->
   <div class="loader-wrapper">
     <div class="loader"></div>

--- a/src/charactersheet/viewmodels/character/character_portrait/index.html
+++ b/src/charactersheet/viewmodels/character/character_portrait/index.html
@@ -19,7 +19,7 @@
          }">
           </character-portrait-view>
         </div>
-        <div class="back">
+        <div class="back rounded bg-white">
           <character-portrait-form params="{
             containerId: elementId,
             show: showBack,

--- a/src/charactersheet/viewmodels/character/character_portrait/index.html
+++ b/src/charactersheet/viewmodels/character/character_portrait/index.html
@@ -1,25 +1,35 @@
-<div id="character-portrait">
-  <flip-card params="{
+<div data-bind="attr: { style: background }">
+  <div
+    id="character-portrait"
+    class="d-flex justify-content-center"
+  >
+    <div class="col-xs-12 col-sm-10 col-md-9 position-relative bg-transparent pt-3 mt-2 mb-3 rounded bordered-transparent">
+      <flip-card params="{
         elementId: 'character-portrait',
         defaultHeight: 150,
-        }">
-    <div class="front">
-      <character-portrait-view params="{
-       containerId: elementId,
-       show: showFront,
-       forceCardResize: forceCardResize,
-       flip: flip
-     }">
-      </character-portrait-view>
-    </div>
-    <div class="back">
-      <character-portrait-form params="{
-        containerId: elementId,
-        show: showBack,
-        forceCardResize: forceCardResize,
-        flip: flip
+        context: { background: background },
       }">
-      </character-portrait-form>
+        <div class="front">
+          <character-portrait-view params="{
+           containerId: elementId,
+           show: showFront,
+           forceCardResize: forceCardResize,
+           background: context.background,
+           flip: flip
+         }">
+          </character-portrait-view>
+        </div>
+        <div class="back">
+          <character-portrait-form params="{
+            containerId: elementId,
+            show: showBack,
+            forceCardResize: forceCardResize,
+            flip: flip
+          }">
+          </character-portrait-form>
+        </div>
+      </flip-card>
+      <party-manager></party-manager>
     </div>
-  </flip-card>
+  </div>
 </div>

--- a/src/charactersheet/viewmodels/character/character_portrait/index.js
+++ b/src/charactersheet/viewmodels/character/character_portrait/index.js
@@ -1,5 +1,5 @@
-import { CharacterPortraitFormModel } from './form';
-import { CharacterPortraitViewModel } from './view';
+import './form';
+import './view';
 
 import ko from 'knockout';
 import template from './index.html';
@@ -10,6 +10,7 @@ class CharacterPortraitModel {
         this.showBack = params.showBack;
         this.resize = params.resize;
         this.flip = params.flip;
+        this.background = ko.observable();
     }
 }
 

--- a/src/charactersheet/viewmodels/character/character_portrait/view.html
+++ b/src/charactersheet/viewmodels/character/character_portrait/view.html
@@ -1,13 +1,12 @@
 <card-edit-actions params="{ flip: $component.flip }"></card-edit-actions>
-<div id="characters"
-    class="container-fluid characters-module-style">
-  <div class="row" style="padding-right: 15px"> <!-- padding for edit button -->
+<div id="characters">
+  <div class="d-flex justify-content-center" style="gap: 2rem;"> <!-- padding for edit button -->
     <!-- ko ifnot: loaded(), completeOn: 'render' -->
     <div style="height: 100px" class="loader-wrapper"><div style="width: 75px; height:75px; margin: 25px auto" class="loader"></div></div>
     <!-- /ko -->
     <!-- ko if: loaded(), completeOn: 'render' -->
-    <div class="col-sm-2 col-xs-12">
-      <div class="circular-profile no-padding center-block bordered"
+    <div class="ml-3 mr-3">
+      <div class="circular-profile no-padding center-block"
         data-bind="attr: {
             height: $component.imageHeight,
             width: $component.imageWidth,
@@ -44,19 +43,37 @@
         ></div>
       </div>
     </div>
-    <div class="col-sm-10 col-xs-12 characters-player-name">
-      <div class="row">
-        <div class="col-xs-12 col-md-12 text-center-xs text-left-sm" data-bind="with: profile">
-            <h3><span id="characterNameLabel" data-bind="text: characterName" /> <small data-bind="with: $component.core">by <span data-bind="text: playerName" /></small></h3>
-
-        </div>
-        <div class="col-xs-12">
-          <character-status-line></character-status-line>
-        </div>
-        <div class="col-xs-12">
-          <party-status></party-status>
-        </div>
+    <div>
+      <!-- ko with: $component.profile -->
+      <div class="h3 mt-0 mb-0">
+        <span id="nameLabel" data-bind="text: characterName"></span>
+        <!-- ko if: $component.core().playerName() -->
+        <small>by <span data-bind="text: $component.core().playerName()"></span></small>
+        <!-- /ko -->
       </div>
+      <!-- /ko -->
+      <div>
+        <character-status-line></character-status-line>
+      </div>
+      <!-- ko with: $component.party -->
+      <!-- ko if: $data.campaign -->
+      <div>
+        <span data-bind="text: campaign.name"></span>
+      </div>
+      <!-- ko if: campaign.setting -->
+      <div>
+        <small data-bind="text: campaign.setting"></small>
+      </div>
+      <!-- /ko -->
+      <!-- /ko -->
+      <!-- /ko -->
+      <div>
+        <party-status></party-status>
+      </div>
+    </div>
+    <div class="d-flex-1">
+      <!-- Spacer -->
+      &nbsp;
     </div>
     <!-- /ko -->
   </div>

--- a/src/charactersheet/viewmodels/character/character_portrait/view.js
+++ b/src/charactersheet/viewmodels/character/character_portrait/view.js
@@ -115,7 +115,7 @@ export class CharacterPortraitViewModel {
     }
 
     _headerBackgroundStyle() {
-        if (!this.party().campaign.headerImageUrl) {
+        if (!this.party() || !this.party().campaign.headerImageUrl) {
             return;
         }
 

--- a/src/charactersheet/viewmodels/character/character_portrait/view.js
+++ b/src/charactersheet/viewmodels/character/character_portrait/view.js
@@ -13,13 +13,14 @@ export class CharacterPortraitViewModel {
     constructor(params) {
         this.loaded = ko.observable(false);
         this.forceCardResize = params.forceCardResize;
+        this.background = params.background
         this.flip = params.flip;
         this.subscriptions = [];
         this.core = ko.observable(new Core());
         this.profile = ko.observable(new Profile());
         this.otherStats = ko.observable(new OtherStats());
         this.profileImage = ko.observable(new ProfileImage());
-        this.isConnectedToParty = ko.observable(!!PartyService.party);
+        this.party = ko.observable(PartyService.party);
         this.user = UserServiceManager.sharedService().user;
 
         this.imageHeight = 80;
@@ -36,6 +37,7 @@ export class CharacterPortraitViewModel {
         await this.profileImage().load({uuid: key});
         this.loaded(true);
         this.forceCardResize();
+        this.updateBackground();
     }
 
     refresh = async () => {
@@ -44,7 +46,10 @@ export class CharacterPortraitViewModel {
         await this.profile().load({uuid: key});
         await this.otherStats().load({uuid: key});
         await this.profileImage().load({uuid: key});
+        this.updateBackground();
     };
+
+    isConnectedToParty = ko.pureComputed(() => !!this.party());
 
     imageDidUpdate = (image) => {
         this.profileImage().importValues(image.exportValues());
@@ -105,8 +110,30 @@ export class CharacterPortraitViewModel {
         this.isConnectedToParty() ? 'success' : 'failure'
     ));
 
+    updateBackground() {
+        this.background(this._headerBackgroundStyle());
+    }
+
+    _headerBackgroundStyle() {
+        if (!this.party().campaign.headerImageUrl) {
+            return;
+        }
+
+        return `
+          background-image:
+            linear-gradient(to bottom, transparent, white),
+            url('${this.party().campaign.headerImageUrl}');
+          background-size: cover;
+          background-position: center;
+          background-repeat: no-repeat;
+        `;
+    }
+
+    // Events
+
     partyDidChange() {
-        this.isConnectedToParty(!!PartyService.party);
+        this.party(PartyService.party);
+        this.updateBackground();
     }
 }
 

--- a/src/charactersheet/viewmodels/character/character_portrait/view.js
+++ b/src/charactersheet/viewmodels/character/character_portrait/view.js
@@ -121,7 +121,7 @@ export class CharacterPortraitViewModel {
 
         return `
           background-image:
-            linear-gradient(to bottom, transparent, white),
+            linear-gradient(to bottom, transparent, 80%, white),
             url('${this.party().campaign.headerImageUrl}');
           background-size: cover;
           background-position: center;

--- a/src/charactersheet/viewmodels/character/companions/index.html
+++ b/src/charactersheet/viewmodels/character/companions/index.html
@@ -1,6 +1,5 @@
-
 <div id="companions-pane">
-  <div class="h4 card-title"> Companions <br />
+  <div class="h4 card-title mt-0"> Companions <br />
     <small>A companion could be a follower, a Ranger&apos;s beast companion, or a familiar. You can also track your Druid's wildshape or Polymorph shapes.</small>
   </div>
   <table class="table table-responsive table-ac-bordered table-hover">
@@ -16,7 +15,7 @@
         AC
         <span data-bind="css: sortArrow('armorClass')"></span>
       </th>
-       <th 
+       <th
           data-bind="click: ()=> {sortBy('maxHitPoints');}"
           class="col-xs-4 col-sm-8 text-center">
           Hit Points
@@ -35,8 +34,8 @@
       <tr
         class="clickable companionRow"
         data-bind="attr: { id: `#companion_row_${uuid()}` }">
-        <td 
-          data-toggle="collapse" 
+        <td
+          data-toggle="collapse"
           data-bind="attr: {
           'data-target': `#companion_list_${uuid()}`,
           }">
@@ -59,11 +58,11 @@
             </div>
           </div>
         </td>
-        <td 
-          data-toggle="collapse" 
+        <td
+          data-toggle="collapse"
           data-bind="
           attr: { 'data-target': `#companion_list_${uuid()}` }">
-          <div 
+          <div
             id="ArmorClassShield"
             class="defenseShield"
             style="
@@ -77,22 +76,22 @@
         </td>
         <td>
           <div class="row d-flex">
-            <div data-toggle="collapse" data-bind="attr: { 'data-target': `#companion_list_${uuid()}` }" 
+            <div data-toggle="collapse" data-bind="attr: { 'data-target': `#companion_list_${uuid()}` }"
               class="hidden-xs col-sm-4 col-md-6 col-lg-8" style="padding: 6px;">
               <div style="padding: 10px"
               data-bind="barProgress: $component.mapToChart($data)"> </div>
             </div>
-            <div  
+            <div
               class="col-xs-12 visible-xs hidden-md hidden-lg text-center">
               <span data-toggle="collapse" data-bind="attr: { 'data-target': `#companion_list_${uuid()}` }, text: usesDisplay()"></span>
-              <mini-health-input 
+              <mini-health-input
               params="id: uuid,
               valueInput: damage,
               max: maxHitPoints,
               onChange: ()=>{$component.onUsedChange($data)}"></mini-health-input>
             </div>
             <div class="hidden-xs col-sm-4 col-md-3 col-lg-2" style="padding: 6px;">
-              <mini-health-input 
+              <mini-health-input
                 params="id: uuid,
                 valueInput: damage,
                 max: maxHitPoints,
@@ -237,7 +236,7 @@
                         </td>
                       </tr>
                     </tbody>
-                    
+
                   </table>
                 </div>
                 <div class="col-xs-12 col-md-6">
@@ -285,7 +284,7 @@
                 <div class="col-xs-12 col-md-6" data-bind="description">
                   <label>Description</label>
                   <div data-bind="markdownPreview: description"></div>
-                </div>              
+                </div>
               </div>
             </div>
             <div class="back">

--- a/src/charactersheet/viewmodels/character/items/index.html
+++ b/src/charactersheet/viewmodels/character/items/index.html
@@ -1,5 +1,5 @@
 <div id="item-pane">
-  <div class="h4 card-title"> Inventory<br />
+  <div class="h4 card-title mt-0"> Inventory<br />
     <small>Don't hoard too much stuff; it's no fun to be encumbered.</small>
   </div>
   <table class="table table-responsive table-ac-bordered table-hover">

--- a/src/charactersheet/viewmodels/character/other_stats/index.html
+++ b/src/charactersheet/viewmodels/character/other_stats/index.html
@@ -5,7 +5,7 @@
         elementId: 'other_stats'
       }">
     <div class="front">
-      <div class="h4 card-title"> Stats </div>
+      <div class="h4 card-title mt-0"> Stats </div>
       <other-stats-view params="{
         containerId: elementId,
         show: showFront,
@@ -13,7 +13,7 @@
       </other-stats-view>
     </div>
     <div class="back">
-      <div class="h4 card-title"> Stats </div>
+      <div class="h4 card-title mt-0"> Stats </div>
       <other-stats-form params="{
       containerId: elementId,
       show: showBack,

--- a/src/charactersheet/viewmodels/character/root/index.html
+++ b/src/charactersheet/viewmodels/character/root/index.html
@@ -1,6 +1,4 @@
 <character-portrait></character-portrait>
-<party-manager></party-manager>
-<div class="spacer"></div>
 <div role="presentation"
      class="secondary-nav visible-xs">
   <button class="btn btn-sm btn-primary"
@@ -27,7 +25,7 @@
     <span class="icon-bar"></span>
   </button>
 </div>
-<div class="navbar-collapse collapse"
+<div class="navbar-collapse collapse main pl-3 pr-3"
      id="descriptionTab">
   <ul class="nav nav-tabs tabs">
     <li role="presentation"
@@ -285,7 +283,7 @@
     </li>
   </ul>
 </div>
-<div class="tab-content">
+<div class="tab-content main pl-3 pr-3">
   <actions-toolbar params="wellState: wellState"></actions-toolbar>
   <div role="tabpanel"
        class="tab-pane"

--- a/src/charactersheet/viewmodels/character/skills/index.html
+++ b/src/charactersheet/viewmodels/character/skills/index.html
@@ -5,7 +5,7 @@
         elementId: 'skills-list'
       }">
     <div class="front">
-      <div class="h4 card-title"> Skills<br />
+      <div class="h4 card-title mt-0"> Skills<br />
         <small>Your Skills take into account your Ability Score modifiers and Proficiency Bonus.</small>
       </div>
       <skills-view params="{
@@ -15,7 +15,7 @@
       </skills-view>
     </div>
     <div class="back">
-      <div class="h4 card-title"> Skills<br />
+      <div class="h4 card-title mt-0"> Skills<br />
         <small>Your Skills take into account your Ability Score modifiers and Proficiency Bonus.</small>
       </div>
       <skills-form-view params="{

--- a/src/charactersheet/viewmodels/character/spell_slots/index.html
+++ b/src/charactersheet/viewmodels/character/spell_slots/index.html
@@ -1,5 +1,5 @@
 <div id="slot-pane">
-  <div class="h4 card-title"> Spell Slots<br />
+  <div class="h4 card-title mt-0"> Spell Slots<br />
     <small>These slots are configurable to reset on a short or long rest. Click on a slot to edit it.</small>
   </div>
   <table class="table table-responsive table-ac-bordered">

--- a/src/charactersheet/viewmodels/character/spell_stats/index.html
+++ b/src/charactersheet/viewmodels/character/spell_stats/index.html
@@ -5,7 +5,7 @@
         elementId: 'spell-stats'
       }">
     <div class="front">
-      <div class="h4 card-title">
+      <div class="h4 card-title mt-0">
         Spell Stats<br />
       </div>
       <hr class="ac-table-header" />
@@ -15,7 +15,7 @@
         }"></spell-stats-view>
     </div>
     <div class="back">
-      <div class="h4 card-title">
+      <div class="h4 card-title mt-0">
         Spell Stats<br />
       </div>
       <hr class="ac-table-header" />

--- a/src/charactersheet/viewmodels/character/stats/form.html
+++ b/src/charactersheet/viewmodels/character/stats/form.html
@@ -1,7 +1,7 @@
 <form class="form-horizontal"
     data-bind="{ submit: $component.submit }">
   <card-submit-actions params="{ reset: $component.reset }"></card-submit-actions>
-  <div class="h4 card-title"> Health <br />
+  <div class="h4 card-title mt-0"> Health <br />
     <small>Click on the edit icon to change max hit points, hit die, or manage damage directly.</small>
   </div>
   <hr class="ac-table-header" />

--- a/src/charactersheet/viewmodels/character/stats/view.html
+++ b/src/charactersheet/viewmodels/character/stats/view.html
@@ -1,5 +1,5 @@
 <card-edit-actions params="{ flip: $component.flip }"></card-edit-actions>
-<div class="h4 card-title"> Health <br />
+<div class="h4 card-title mt-0"> Health <br />
   <small>Click on the edit icon to change max hit points, hit die, or manage damage directly.</small>
 </div>
 <hr class="ac-table-header" />

--- a/src/charactersheet/viewmodels/character/tracker/index.html
+++ b/src/charactersheet/viewmodels/character/tracker/index.html
@@ -1,5 +1,5 @@
 <div id="tracker-pane">
-  <div class="h4 card-title">
+  <div class="h4 card-title mt-0">
     Tracked Features, Feats, and Traits<br />
     <small>Configure to reset on a short or long rest.</small>
   </div>

--- a/src/charactersheet/viewmodels/character/wealth/form.html
+++ b/src/charactersheet/viewmodels/character/wealth/form.html
@@ -1,6 +1,6 @@
 <form data-bind="submit: $component.submit">
   <card-submit-actions params="{reset: $component.reset}"></card-submit-actions>
-  <div class="h4 card-title">
+  <div class="h4 card-title mt-0">
     Coins<br />
     <small>watch for pickpockets</small>
   </div>

--- a/src/charactersheet/viewmodels/character/wealth/view.html
+++ b/src/charactersheet/viewmodels/character/wealth/view.html
@@ -1,5 +1,5 @@
 <card-edit-actions params="{ flip: $component.flip }"></card-edit-actions>
-<div class="h4 card-title">Coins<br />
+<div class="h4 card-title mt-0">Coins<br />
   <small>Watch out for pickpockets.</small>
 </div>
 <hr class="ac-table-header" />

--- a/src/charactersheet/viewmodels/character/weapons/index.html
+++ b/src/charactersheet/viewmodels/character/weapons/index.html
@@ -1,5 +1,5 @@
 <div id="weapon-pane">
-  <div class="h4 card-title"> Weapons<br />
+  <div class="h4 card-title mt-0"> Weapons<br />
     <small>A weapon's To Hit bonus is automatically calculated based on your Strength or Dexterity, proficiency bonus, magical modifier, and property. Use the To Hit Modifier to adjust for features, feats, or special cases.</small>
   </div>
   <table class="table table-responsive table-ac-bordered table-hover">

--- a/src/charactersheet/viewmodels/common/exhibit/index.html
+++ b/src/charactersheet/viewmodels/common/exhibit/index.html
@@ -1,4 +1,4 @@
-<div class="card-title h4">
+<div class="card-title h4 mt-0">
   Exhibit<br />
   <!-- ko if: playerType() == 'character' -->
   <small>

--- a/src/charactersheet/viewmodels/common/media_manager/front.html
+++ b/src/charactersheet/viewmodels/common/media_manager/front.html
@@ -15,7 +15,8 @@
             type="button"
             data-bind="click: clickFileInput"
           >
-            Upload image
+            <i class="fa fa-upload mr-1"></i>
+            Upload
           </button>
           <input
             type="file"
@@ -33,7 +34,8 @@
             type="button"
             data-bind="click: browse"
           >
-            Browse images
+            <i class="fa fa-image mr-1"></i>
+            Browse
           </button>
         </div>
       </div>

--- a/src/charactersheet/viewmodels/common/media_manager/front.js
+++ b/src/charactersheet/viewmodels/common/media_manager/front.js
@@ -6,7 +6,7 @@ import {
 } from 'charactersheet/utilities';
 import { ViewModel } from 'charactersheet/viewmodels/abstract';
 import { UserServiceManager } from 'charactersheet/services';
-import { observable, components, pureComputed, computed } from 'knockout';
+import { observable, components, pureComputed } from 'knockout';
 import template from './front.html';
 
 export class MediaManagerViewModel extends ViewModel {

--- a/src/charactersheet/viewmodels/common/notes/index.html
+++ b/src/charactersheet/viewmodels/common/notes/index.html
@@ -1,5 +1,5 @@
 <div id="notes-pane">
-  <div class="h4 card-title"> Notes<br />
+  <div class="h4 card-title mt-0"> Notes<br />
     <small>“Consult the Book of Armaments!” -King Arthur</small>
   </div>
   <table class="table table-responsive table-ac-bordered table-hover">

--- a/src/charactersheet/viewmodels/common/party/index.html
+++ b/src/charactersheet/viewmodels/common/party/index.html
@@ -1,4 +1,4 @@
-<div class="card-title h4">
+<div class="card-title h4 mt-0">
   <span data-bind="if: filterByOnline">Online</span> Party Members<br />
   <small>
     <span data-bind="ifnot: filterByOnline">

--- a/src/charactersheet/viewmodels/common/party_manager/index.html
+++ b/src/charactersheet/viewmodels/common/party_manager/index.html
@@ -1,5 +1,5 @@
-<div class="collapse mb-3" id="party-manager-form">
-  <div class="card-title h4">
+<div class="collapse bg-white rounded bordered" id="party-manager-form">
+  <div class="card-title h4 mt-0">
     <div class="pull-right">
       <button
         type="button"

--- a/src/charactersheet/viewmodels/common/root/index.html
+++ b/src/charactersheet/viewmodels/common/root/index.html
@@ -16,7 +16,7 @@
 <!-- /ko -->
 <div id="content">
   <!-- Begin Nav -->
-  <nav class="navbar navbar-default navbar-static-top">
+  <nav class="navbar navbar-default navbar-static-top mb-0">
     <div class="container-fluid">
       <div style="padding-left: 5%; padding-right: 5%"
           class="col-xs-12 ">
@@ -87,6 +87,39 @@
   <!-- Chat Flyout -->
   <chat></chat>
 
+  <user-notifications></user-notifications>
+  <div class="container-fluid pl-0 pr-0">
+    <!-- ko if: shouldShowApp -->
+      <!-- ko if: selectedCore() && selectedCore().type.name() == 'character' -->
+      <character-root
+        params="activeCharacter: selectedCore"
+      ></character-root>
+      <!-- /ko -->
+      <!-- ko if: selectedCore() && selectedCore().type.name() == 'dm' -->
+      <dm-root params="activeCharacter: selectedCore"></dm-root>
+      <!-- /ko -->
+    <!-- /ko -->
+    <!-- ko if: shouldShowWizard -->
+    <wizard></wizard>
+    <!-- /ko -->
+    <!-- ko if: shouldShowPicker -->
+    <core-picker params="state: state"></core-picker>
+    <!-- /ko -->
+  </div>
+
+  <!-- Additional Core-Related Modals -->
+  <!-- ko if: shouldShowApp -->
+    <!-- Switch Characters Modal -->
+    <!-- ko if: characterAndGamesModalStatus -->
+    <characters params="modalStatus: characterAndGamesModalStatus"></characters>
+    <!-- /ko -->
+    <!-- Share Modal -->
+    <!-- ko if: shareModalStatus -->
+    <share params="modalStatus: shareModalStatus"></share>
+    <!-- /ko -->
+  <!-- /ko -->
+</div>
+
   <!-- Session expiry modal -->
   <div class="modal fade"
       tabindex="-1"
@@ -139,38 +172,7 @@
       </div>
     </div>
   </div>
-  <user-notifications></user-notifications>
-  <div class="container-fluid main pl-3 pr-3">
-    <!-- ko if: shouldShowApp -->
-      <!-- ko if: selectedCore() && selectedCore().type.name() == 'character' -->
-      <character-root
-        params="activeCharacter: selectedCore"
-      ></character-root>
-      <!-- /ko -->
-      <!-- ko if: selectedCore() && selectedCore().type.name() == 'dm' -->
-      <dm-root params="activeCharacter: selectedCore"></dm-root>
-      <!-- /ko -->
-    <!-- /ko -->
-    <!-- ko if: shouldShowWizard -->
-    <wizard></wizard>
-    <!-- /ko -->
-    <!-- ko if: shouldShowPicker -->
-    <core-picker params="state: state"></core-picker>
-    <!-- /ko -->
-  </div>
 
-  <!-- Additional Core-Related Modals -->
-  <!-- ko if: shouldShowApp -->
-    <!-- Switch Characters Modal -->
-    <!-- ko if: characterAndGamesModalStatus -->
-    <characters params="modalStatus: characterAndGamesModalStatus"></characters>
-    <!-- /ko -->
-    <!-- Share Modal -->
-    <!-- ko if: shareModalStatus -->
-    <share params="modalStatus: shareModalStatus"></share>
-    <!-- /ko -->
-  <!-- /ko -->
-</div>
 <!-- Footer -->
 <div id="footer" class="footer mt-3 pt-3 pb-3">
   <div class="container">

--- a/src/charactersheet/viewmodels/dm/campaign_maps_and_images/index.html
+++ b/src/charactersheet/viewmodels/dm/campaign_maps_and_images/index.html
@@ -1,5 +1,5 @@
 <div id="moi-campaign-pane">
-  <div class="card-title h4">
+  <div class="card-title h4 mt-0">
     Campaign Maps &amp; Images<br />
     <small>A place for all of the great places and maps in your world.</small>
   </div>

--- a/src/charactersheet/viewmodels/dm/dm_portrait/form.html
+++ b/src/charactersheet/viewmodels/dm/dm_portrait/form.html
@@ -63,9 +63,12 @@
         "
       ></textarea>
     </div>
-    <!-- ko with: entity -->
     <div class="col-xs-12">
       <div class="row">
+
+        <!-- Profile Image -->
+        <!-- ko with: entity -->
+
         <div class="col-sm-2 hidden-xs">
           <div style="margin-top: 15%;" class="circular-profile center-block"
               data-bind="attr: {
@@ -90,8 +93,8 @@
             </div>
           </div>
         </div>
-        <div class="col-sm-10">
-          <div class="form-group col-xs-12 col-lg-6">
+        <div class="col-xs-12 col-sm-4 pr-2 border-right">
+          <div class="form-group">
             <!-- Image URL -->
             <label class="control-label"> Image Link </label>
             <div class="input-group">
@@ -117,8 +120,6 @@
               "
             />
             <!-- /ko -->
-          </div>
-          <div class="form-group  col-xs-12 col-lg-6">
             <!-- Image URL -->
             <label class="control-label"> Gravatar Email </label>
             <div class="input-group">
@@ -142,20 +143,92 @@
             <!-- Picker URL -->
             <label class="control-label">
               <input type="radio"
+                  class="mr-1"
                   name="imageType"
                   value="picker"
-                  data-bind="checked: $component.imageType"> Choose a default </label>
+                  data-bind="checked: $component.imageType">Choose a default </label>
             <small class="help-block">Choose from a set of default images.</small>
           </div>
+          <!-- ko if: $component.imageType() === 'picker' -->
+          <image-picker params="
+            cells: $component.stockImages,
+            selectedCells: $component.selectedStockImage,
+            multiselect: false
+          "></image-picker>
+          <!-- /ko -->
         </div>
+
+        <!-- /ko -->
+
+        <!-- Header Image -->
+        <!-- ko with: campaign -->
+
+        <div class="col-xs-12 col-sm-4">
+          <div class="form-group">
+            <!-- Header Image URL -->
+            <label class="control-label"> Header Image Link </label>
+            <div class="input-group">
+              <span class="input-group-addon"
+                  style="line-height: 0.75">
+                <input type="radio"
+                    name="headerImageType"
+                    value="url"
+                    data-bind="checked: $component.headerImageType">
+              </span>
+              <input
+                type="url"
+                class="form-control"
+                data-bind="
+                  event: { blur: $component.reviewInput, invalid: $component.invalidate },
+                  value: $component.headerImageType() === 'url' ? headerImageUrl() : '',
+                  enable: $component.headerImageType() === 'url'
+                "
+              >
+            </div>
+            <small class="help-block">Paste in a link to your header image. Make sure it's the full image link though.</small>
+            <d20photos-help />
+            <!-- ko if: $component.headerImageType() === 'url' -->
+            <media-manager
+              params="
+                forceCardResize: $parents[1].forceCardResize,
+                setImageUrl: headerImageUrl,
+                tabId: 'dm_portrait',
+              "
+            />
+            <!-- /ko -->
+          </div>
+          <div class="form-group">
+            <!-- Default Picker URL -->
+            <label class="control-label">
+              <input type="radio"
+                  class="mr-1"
+                  name="headerImageType"
+                  value="picker"
+                  data-bind="checked: $component.headerImageType">Choose a default </label>
+            <small class="help-block">Choose from a set of default images.</small>
+          </div>
+          <!-- ko if: $component.headerImageType() === 'picker' -->
+          <image-picker params="
+            cells: $component.stockHeaderImages,
+            selectedCells: $component.selectedStockHeaderImage,
+            multiselect: false,
+            style: 'thumbnail',
+          "></image-picker>
+          <!-- /ko -->
+        </div>
+        <div class="col-sm-2 hidden-xs">
+          <div class="center-block pl-2 pr-2">
+            <div class="image-upload-preview text-center">
+              <!-- ko if: headerImageUrl -->
+              <img class="img-thumbnail" data-bind="attr: {src: headerImageUrl}">
+              <!-- /ko -->
+            </div>
+          </div>
+        </div>
+
+        <!-- /ko -->
       </div>
     </div>
-    <!-- ko if: $component.imageType() === 'picker' -->
-    <div class="col-xs-12">
-      <image-picker params="cells: $component.stockImages, selectedCells: $component.selectedStockImage, multiselect: false"></image-picker>
-    </div>
-    <!-- /ko -->
-    <!-- /ko -->
     <form-submit-actions params="{reset: $component.reset}"></form-submit-actions>
   </div>
   <!-- /ko -->

--- a/src/charactersheet/viewmodels/dm/dm_portrait/form.html
+++ b/src/charactersheet/viewmodels/dm/dm_portrait/form.html
@@ -180,7 +180,7 @@
                 class="form-control"
                 data-bind="
                   event: { blur: $component.reviewInput, invalid: $component.invalidate },
-                  value: $component.headerImageType() === 'url' ? headerImageUrl() : '',
+                  value: $component.headerImageType() === 'url' ? headerImageUrl : '',
                   enable: $component.headerImageType() === 'url'
                 "
               >

--- a/src/charactersheet/viewmodels/dm/dm_portrait/form.html
+++ b/src/charactersheet/viewmodels/dm/dm_portrait/form.html
@@ -186,7 +186,6 @@
               >
             </div>
             <small class="help-block">Paste in a link to your header image. Make sure it's the full image link though.</small>
-            <d20photos-help />
             <!-- ko if: $component.headerImageType() === 'url' -->
             <media-manager
               params="
@@ -196,6 +195,7 @@
               "
             />
             <!-- /ko -->
+            <d20photos-help />
           </div>
           <div class="form-group">
             <!-- Default Picker URL -->

--- a/src/charactersheet/viewmodels/dm/dm_portrait/form.html
+++ b/src/charactersheet/viewmodels/dm/dm_portrait/form.html
@@ -1,5 +1,5 @@
 <form data-bind="{ submit: $component.submit }">
-  <div class="h4 card-title"> Name, Setting &amp; Portrait </div>
+  <div class="h4 card-title mt-0"> Name, Setting &amp; Portrait </div>
   <!-- ko ifnot: loaded(), completeOn: 'render' -->
   <div class="loader-wrapper">
     <div class="loader"></div>

--- a/src/charactersheet/viewmodels/dm/dm_portrait/form.js
+++ b/src/charactersheet/viewmodels/dm/dm_portrait/form.js
@@ -49,7 +49,7 @@ export class CampaignPortraitFormModel extends AbstractFormModel {
         await this.campaign().load({uuid: CoreManager.activeCore().uuid()});
         await this.core().importValues(CoreManager.activeCore().exportValues());
         this.selectedStockImage([]);
-        this.selectedStockImage([]);
+        this.selectedStockHeaderImage([]);
         this.configureImages();
         this.configureHeaderImages();
     }
@@ -73,6 +73,16 @@ export class CampaignPortraitFormModel extends AbstractFormModel {
             if (stockImage) {
                 this.selectedStockImage().push(stockImage);
                 this.imageType('picker');
+            }
+        }
+
+        this.headerImageType('url');
+        if (this.campaign().headerImageUrl()) {
+            const stockImage = find(this.stockHeaderImages(), {'image': this.campaign().headerImageUrl()});
+            if (stockImage) {
+                console.log(stockImage)
+                this.selectedStockHeaderImage.push(stockImage);
+                this.headerImageType('picker');
             }
         }
     }
@@ -122,7 +132,7 @@ export class CampaignPortraitFormModel extends AbstractFormModel {
         if (type === 'picker') {
             this.entity().type('url');
         } else {
-            this.entity().type(this.imageType());
+            this.entity().type(this.headerImageType());
         }
         if (type === 'picker' && !this.showStockImages()) {
             this.showStockImages(true);

--- a/src/charactersheet/viewmodels/dm/dm_portrait/form.js
+++ b/src/charactersheet/viewmodels/dm/dm_portrait/form.js
@@ -1,5 +1,6 @@
 import { Core, ProfileImage } from 'charactersheet/models/common';
 import { CoreManager, Fixtures, Notifications } from 'charactersheet/utilities';
+import { PartyService } from 'charactersheet/services/common/account/party_service';
 import { AbstractFormModel } from 'charactersheet/viewmodels/abstract';
 import { Campaign } from 'charactersheet/models/dm';
 import autoBind from 'auto-bind';
@@ -159,6 +160,10 @@ export class CampaignPortraitFormModel extends AbstractFormModel {
         CoreManager.activeCore().playerName(this.core().playerName());
         this.selectedStockImage([]);
         Notifications.campaign.playerName.changed.dispatch(this.core());
+
+        // Poke the party to notify of any out-of-band changes
+        // like the header image changing that needs refresh.
+        PartyService.updatePresence();
     }
 
     validation = {

--- a/src/charactersheet/viewmodels/dm/dm_portrait/index.html
+++ b/src/charactersheet/viewmodels/dm/dm_portrait/index.html
@@ -1,43 +1,53 @@
-<div id="dm-portrait" data-bind="visible: show">
-  <flip-card params="{
-        elementId: 'dm-portrait',
-        defaultHeight: 150,
+<div data-bind="attr: { style: show() ? background : '' }">
+  <div
+    id="dm-portrait"
+    class="d-flex justify-content-center"
+    data-bind="visible: show"
+  >
+    <div class="col-xs-12 col-sm-10 col-md-9 position-relative bg-transparent pt-3 mt-2 mb-3 rounded">
+    <flip-card params="{
+          elementId: 'dm-portrait',
+          defaultHeight: 150,
+          context: { background: background },
+          }">
+      <div class="front">
+        <dm-portrait-view params="{
+         containerId: elementId,
+         show: showFront,
+         background: context.background,
+         forceCardResize: forceCardResize,
+         flip: flip
+       }">
+        </dm-portrait-view>
+      </div>
+      <div class="back rounded bg-white">
+        <dm-portrait-form params="{
+          containerId: elementId,
+          show: showBack,
+          forceCardResize: forceCardResize,
+          flip: flip
         }">
-    <div class="front">
-      <dm-portrait-view params="{
-       containerId: elementId,
-       show: showFront,
-       forceCardResize: forceCardResize,
-       flip: flip
-     }">
-      </dm-portrait-view>
+        </dm-portrait-form>
+      </div>
+    </flip-card>
     </div>
-    <div class="back">
-      <dm-portrait-form params="{
-        containerId: elementId,
-        show: showBack,
-        forceCardResize: forceCardResize,
-        flip: flip
-      }">
-      </dm-portrait-form>
-    </div>
-  </flip-card>
-</div>
-<div class="pull-right text-right" data-bind="visible: show">
-  <button
-    class="btn btn-xs btn-link"
-    data-bind="click: toggleShow"
-    role="button"
-  >
-    <i class="fa fa-chevron-up"></i>&nbsp;Hide
-  </button>
-</div>
-<div class="text-right" data-bind="hidden: show">
-  <button
-    class="btn btn-xs btn-link"
-    data-bind="click: toggleShow"
-    role="button"
-  >
-    <i class="fa fa-chevron-down"></i>&nbsp;Show
-  </button>
+  </div>
+  <div class="pull-right text-right" data-bind="visible: show">
+    <button
+      class="btn btn-xs btn-link"
+      data-bind="click: toggleShow"
+      role="button"
+    >
+      <i class="fa fa-chevron-up"></i>&nbsp;Hide
+    </button>
+  </div>
+  <div class="text-right" data-bind="hidden: show">
+    <button
+      class="btn btn-xs btn-link"
+      data-bind="click: toggleShow"
+      role="button"
+    >
+      <i class="fa fa-chevron-down"></i>&nbsp;Show
+    </button>
+  </div>
 </div>

--- a/src/charactersheet/viewmodels/dm/dm_portrait/index.html
+++ b/src/charactersheet/viewmodels/dm/dm_portrait/index.html
@@ -4,32 +4,33 @@
     class="d-flex justify-content-center"
     data-bind="visible: show"
   >
-    <div class="col-xs-12 col-sm-10 col-md-9 position-relative bg-transparent pt-3 mt-2 mb-3 rounded">
-    <flip-card params="{
-          elementId: 'dm-portrait',
-          defaultHeight: 150,
-          context: { background: background },
+    <div class="col-xs-12 col-sm-10 col-md-9 position-relative bg-transparent pt-3 mt-2 mb-3 rounded bordered-transparent">
+      <flip-card params="{
+            elementId: 'dm-portrait',
+            defaultHeight: 150,
+            context: { background: background },
+            }">
+        <div class="front">
+          <dm-portrait-view params="{
+           containerId: elementId,
+           show: showFront,
+           background: context.background,
+           forceCardResize: forceCardResize,
+           flip: flip
+         }">
+          </dm-portrait-view>
+        </div>
+        <div class="back rounded bg-white">
+          <dm-portrait-form params="{
+            containerId: elementId,
+            show: showBack,
+            forceCardResize: forceCardResize,
+            flip: flip
           }">
-      <div class="front">
-        <dm-portrait-view params="{
-         containerId: elementId,
-         show: showFront,
-         background: context.background,
-         forceCardResize: forceCardResize,
-         flip: flip
-       }">
-        </dm-portrait-view>
-      </div>
-      <div class="back rounded bg-white">
-        <dm-portrait-form params="{
-          containerId: elementId,
-          show: showBack,
-          forceCardResize: forceCardResize,
-          flip: flip
-        }">
-        </dm-portrait-form>
-      </div>
-    </flip-card>
+          </dm-portrait-form>
+        </div>
+      </flip-card>
+      <party-manager></party-manager>
     </div>
   </div>
   <div class="pull-right text-right" data-bind="visible: show">

--- a/src/charactersheet/viewmodels/dm/dm_portrait/index.js
+++ b/src/charactersheet/viewmodels/dm/dm_portrait/index.js
@@ -11,6 +11,7 @@ class CharacterPortraitModel {
         this.resize = params.resize;
         this.flip = params.flip;
         this.show = ko.observable(true);
+        this.background = ko.observable();
     }
 
     toggleShow() {

--- a/src/charactersheet/viewmodels/dm/dm_portrait/view.html
+++ b/src/charactersheet/viewmodels/dm/dm_portrait/view.html
@@ -7,7 +7,7 @@
     <!-- ko if: loaded(), completeOn: 'render' -->
     <div class="ml-3 mr-3">
       <div
-        class="circular-profile no-padding center-block bordered bg-white"
+        class="circular-profile no-padding center-block"
         data-bind="attr: { css: imageBorderClass }"
       >
         <div class="image-upload-preview text-center" data-bind="with: profileImage">

--- a/src/charactersheet/viewmodels/dm/dm_portrait/view.html
+++ b/src/charactersheet/viewmodels/dm/dm_portrait/view.html
@@ -1,14 +1,13 @@
 <card-edit-actions params="{ flip: $component.flip }"></card-edit-actions>
-<div id="characters"
-    class="container-fluid characters-module-style">
-  <div class="row" style="padding-right: 15px"> <!-- padding for edit button -->
+<div id="characters">
+  <div class="d-flex justify-content-center" style="gap: 2rem;"> <!-- padding for edit button -->
     <!-- ko ifnot: loaded(), completeOn: 'render' -->
-    <div style="hieight: 100px" class="loader-wrapper"><div style="width: 75px; height:75px; margin: 25px auto" class="loader"></div></div>
+    <div style="height: 100px" class="loader-wrapper"><div style="width: 75px; height:75px; margin: 25px auto" class="loader"></div></div>
     <!-- /ko -->
     <!-- ko if: loaded(), completeOn: 'render' -->
-    <div class="col-sm-2 col-xs-12">
+    <div class="ml-3 mr-3">
       <div
-        class="circular-profile no-padding center-block bordered"
+        class="circular-profile no-padding center-block bordered bg-white"
         data-bind="attr: { css: imageBorderClass }"
       >
         <div class="image-upload-preview text-center" data-bind="with: profileImage">
@@ -40,46 +39,44 @@
         ></div>
       </div>
     </div>
-    <div class="col-sm-10 col-xs-12 characters-player-name">
-      <div class="row">
-        <div class="col-xs-12 col-md-12 text-center-xs text-left-sm">
-          <div class="row" data-bind="with: $component.core">
-            <div class="col-xs-12 h3">
-              <span id="nameLabel" data-bind="text: $component.campaign().name"></span>
-              <!-- ko if: playerName -->
-              <small>by <span data-bind="text: playerName"></span></small>
-              <!-- /ko -->
-            </div>
-            <!-- ko with: $component.campaign -->
-            <div class="col-xs-12 col-sm-8">
-                <div>
-                  <span data-bind="text: setting" />
-                  <!-- ko if: motif -->
-                  (<span data-bind="text: motif" />)
-                  <!-- /ko -->
-                  <!-- ko if: description -->
-                  <hr class="mt-2 mb-1"/>
-                  <div
-                    style="font-size: small;"
-                    data-bind="text: description"
-                  ></div>
-                  <hr class="mt-1 mb-2"/>
-                  <!-- /ko -->
-                </div>
-            </div>
-            <!-- /ko -->
-          </div>
-        </div>
-        <div class="col-xs-12">
-          <party-status-line></party-status-line>
-        </div>
-        <div class="col-xs-12" data-bind="if: timeSinceLabel">
-          <small data-bind="text: timeSinceLabel" />
-        </div>
-        <div class="col-xs-12">
-          <party-status></party-status>
-        </div>
+    <div>
+      <!-- ko with: $component.core -->
+      <div class="h3 mt-0 mb-0">
+        <span id="nameLabel" data-bind="text: $component.campaign().name"></span>
+        <!-- ko if: playerName -->
+        <small>by <span data-bind="text: playerName"></span></small>
+        <!-- /ko -->
       </div>
+      <!-- ko with: $component.campaign -->
+      <div>
+        <span data-bind="text: setting" />
+        <!-- ko if: motif -->
+        (<span data-bind="text: motif" />)
+        <!-- /ko -->
+        <!-- ko if: description -->
+        <hr class="mt-2 mb-1"/>
+        <div
+          style="font-size: small;"
+          data-bind="text: description"
+        ></div>
+        <hr class="mt-1 mb-2"/>
+        <!-- /ko -->
+      </div>
+      <!-- /ko -->
+      <!-- /ko -->
+      <div>
+        <party-status-line></party-status-line>
+      </div>
+      <!-- ko if: timeSinceLabel -->
+      <small class="d-block" data-bind="text: timeSinceLabel"></small>
+      <!-- /ko -->
+      <div>
+        <party-status></party-status>
+      </div>
+    </div>
+    <div class="d-flex-1">
+      <!-- Spacer -->
+      &nbsp;
     </div>
     <!-- /ko -->
   </div>

--- a/src/charactersheet/viewmodels/dm/dm_portrait/view.js
+++ b/src/charactersheet/viewmodels/dm/dm_portrait/view.js
@@ -13,6 +13,7 @@ export class CharacterPortraitViewModel {
     constructor(params) {
         this.loaded = ko.observable(false);
         this.forceCardResize = params.forceCardResize;
+        this.background = params.background
         this.flip = params.flip;
         this.subscriptions = [];
         this.core = ko.observable(new Core());
@@ -34,6 +35,7 @@ export class CharacterPortraitViewModel {
         await this.profileImage().load({uuid: key});
         this.loaded(true);
         this.forceCardResize();
+        this.updateBackground();
     }
 
     refresh = async () => {
@@ -41,6 +43,7 @@ export class CharacterPortraitViewModel {
         this.core().importValues(CoreManager.activeCore().exportValues());
         await this.campaign().load({uuid: key});
         await this.profileImage().load({uuid: key});
+        this.updateBackground();
     };
 
     setUpSubscriptions = () => {
@@ -106,6 +109,25 @@ export class CharacterPortraitViewModel {
         return Math.round((now-day.getTime())/(1000*60*60*24));
     };
 
+    updateBackground() {
+        this.background(this._headerBackgroundStyle());
+    }
+
+    _headerBackgroundStyle() {
+        if (!this.campaign().headerImageUrl()) {
+            return;
+        }
+
+        return `
+          background-image:
+            linear-gradient(to bottom, transparent, white),
+            url('${this.campaign().headerImageUrl()}');
+          background-size: cover;
+          background-position: center;
+          background-repeat: no-repeat;
+        `;
+    }
+
     // Events
 
     partyDidChange() {
@@ -122,6 +144,7 @@ export class CharacterPortraitViewModel {
 
     campaignDidUpdate = (campaign) => {
         this.campaign().importValues(campaign.exportValues());
+        this.updateBackground();
     };
 }
 

--- a/src/charactersheet/viewmodels/dm/dm_portrait/view.js
+++ b/src/charactersheet/viewmodels/dm/dm_portrait/view.js
@@ -120,7 +120,7 @@ export class CharacterPortraitViewModel {
 
         return `
           background-image:
-            linear-gradient(to bottom, transparent, white),
+            linear-gradient(to bottom, transparent, 85%, white),
             url('${this.campaign().headerImageUrl()}');
           background-size: cover;
           background-position: center;

--- a/src/charactersheet/viewmodels/dm/initiative-tracker/index.html
+++ b/src/charactersheet/viewmodels/dm/initiative-tracker/index.html
@@ -1,5 +1,5 @@
 <div id="initiative-pane">
-  <div class="card-title h4">
+  <div class="card-title h4 mt-0">
     Initiative<br />
     <small>
       <span data-bind="ifnot: filterByOnline">

--- a/src/charactersheet/viewmodels/dm/root/index.html
+++ b/src/charactersheet/viewmodels/dm/root/index.html
@@ -1,5 +1,4 @@
 <dm-portrait></dm-portrait>
-<party-manager></party-manager>
 <div class="navbar-header tab-actions"><button type="button"
           class="btn btn-block navbar-toggle collapsed"
           data-toggle="collapse"

--- a/src/charactersheet/viewmodels/dm/root/index.html
+++ b/src/charactersheet/viewmodels/dm/root/index.html
@@ -12,7 +12,7 @@
     <span class="icon-bar"></span>
   </button>
 </div>
-<div class="navbar-collapse collapse" id="dm-tab-list">
+<div class="navbar-collapse collapse main pl-3 pr-3" id="dm-tab-list">
   <ul class="nav nav-tabs tabs">
     <li role="presentation" id="tabEncountersLink" data-bind="click: activateEncounterTab">
       <a href="#encounter" aria-controls="encounter-tab" role="tab" data-toggle="tab" class="tab-subtext">
@@ -58,7 +58,7 @@
     </li>
   </ul>
 </div>
-<div class="tab-content">
+<div class="tab-content main pl-3 pr-3">
   <div role="tabpanel" class="tab-pane" id="encounter" data-bind="css: encounterTabStatus">
     <encounter params="{tabId: 'encounter-tab'}"></encounter>
   </div>

--- a/src/style/site.css
+++ b/src/style/site.css
@@ -2491,6 +2491,10 @@ tr .panel {
   border: 2px solid var(--border-color);
 }
 
+.bordered-transparent {
+  border: 2px solid rgba(255, 255, 255, 0.4);
+}
+
 .rounded {
   border-radius: 4px;
 }
@@ -2524,7 +2528,7 @@ tr .panel {
 }
 
 .bg-transparent {
-  background-color: rgba(255, 255, 255, 0.55);
+  background-color: rgba(255, 255, 255, 0.65);
 }
 
 .text-white {

--- a/src/style/site.css
+++ b/src/style/site.css
@@ -345,6 +345,7 @@ small {
   -webkit-border-radius: 42px;
   -moz-border-radius: 42px;
   overflow:hidden;
+  background: #ccc;
 }
 
 .no-padding {
@@ -2172,7 +2173,7 @@ tr .panel {
 }
 
 .patron-circle {
-  border: 4px solid transparent;
+  border: 2px solid transparent;
 }
 
 .patron-circle.gold {
@@ -2242,6 +2243,10 @@ tr .panel {
   justify-content: space-between;
 }
 
+.justify-content-start {
+  justify-content: start;
+}
+
 .justify-content-center {
   justify-content: center;
 }
@@ -2266,6 +2271,10 @@ tr .panel {
   padding-top: 1.5rem;
 }
 
+.pt-4 {
+  padding-top: 2rem;
+}
+
 .pb-0 {
   padding-bottom: 0rem;
 }
@@ -2280,6 +2289,10 @@ tr .panel {
 
 .pb-3 {
   padding-bottom: 1.5rem;
+}
+
+.pb-4 {
+  padding-bottom: 2rem;
 }
 
 .pl-0 {
@@ -2298,6 +2311,10 @@ tr .panel {
   padding-left: 1.5rem;
 }
 
+.pl-4 {
+  padding-left: 2rem;
+}
+
 .pr-0 {
   padding-right: 0rem;
 }
@@ -2312,6 +2329,10 @@ tr .panel {
 
 .pr-3 {
   padding-right: 1.5rem;
+}
+
+.pr-4 {
+  padding-right: 2rem;
 }
 
 .p-auto {
@@ -2342,6 +2363,14 @@ tr .panel {
   margin-left: 1.5rem !important;
 }
 
+.ml-4 {
+  margin-left: 2rem !important;
+}
+
+.ml-5 {
+  margin-left: 2.5rem !important;
+}
+
 .mr-auto {
   margin-right: auto !important;
 }
@@ -2356,6 +2385,14 @@ tr .panel {
 
 .mr-3 {
   margin-right: 1.5rem !important;
+}
+
+.mr-4 {
+  margin-right: 2rem !important;
+}
+
+.mr-5 {
+  margin-right: 2.5rem !important;
 }
 
 .mt-auto {
@@ -2480,6 +2517,14 @@ tr .panel {
 
 .bg-danger {
   background-color: #925d07;
+}
+
+.bg-white {
+  background-color: white;
+}
+
+.bg-transparent {
+  background-color: rgba(255, 255, 255, 0.55);
 }
 
 .text-white {

--- a/src/style/site.css
+++ b/src/style/site.css
@@ -339,13 +339,13 @@ small {
 }
 
 .circular-profile {
-  width: 84px;
-  height: 84px;
+  width: 80px;
+  height: 80px;
   border-radius: 42px;
   -webkit-border-radius: 42px;
   -moz-border-radius: 42px;
   overflow:hidden;
-  background: #ccc;
+  background-color: #ccc;
 }
 
 .no-padding {
@@ -528,6 +528,10 @@ textarea.dark-area {
 
 .img-circle.active {
   border-radius: 50%;
+  border: 5px solid #18bc9c;
+}
+
+.img-thumbnail.active {
   border: 5px solid #18bc9c;
 }
 
@@ -2173,7 +2177,7 @@ tr .panel {
 }
 
 .patron-circle {
-  border: 2px solid transparent;
+  border: 3px solid transparent;
 }
 
 .patron-circle.gold {

--- a/src/style/site.css
+++ b/src/style/site.css
@@ -2536,7 +2536,7 @@ tr .panel {
 }
 
 .bg-transparent {
-  background-color: rgba(255, 255, 255, 0.65);
+  background-color: rgba(255, 255, 255, 0.85);
 }
 
 .text-white {


### PR DESCRIPTION
### Summary

DMs can now set an image as their "header image" for their campaign which would render in the UI in the following ways:

1. The DM's own Campaign in Core would use this header (see screenshot)
2. The Campaign Share Sheet "big header" would use this header as the background (see screenshot)
3. Any players in the current party with the DM's campaign would get their header automatically set to the same one  

Along with 3, the campaign name is also displayed in the UI for a player with a DM in the party. This allows Party members to feel more like they're in a campaign of the DM's creation, rather than just seeing the party name `handsome-fox-0012` or something 

The images I added for the defaults are from d20.photos.

### Screenshots

<img width="1849" height="1398" alt="Screenshot 2025-07-25 at 2 15 51 PM" src="https://github.com/user-attachments/assets/68e276ed-52bf-4590-ac74-8c23c1751d51" />

<img width="1849" height="1398" alt="Screenshot 2025-07-25 at 2 15 57 PM" src="https://github.com/user-attachments/assets/6e8700f2-db19-4528-b27f-ac5421d08809" />
<img width="1849" height="1398" alt="Screenshot 2025-07-25 at 2 16 12 PM" src="https://github.com/user-attachments/assets/c9e49329-8917-4d58-bc7c-1693bc060b71" />
<img width="1849" height="1398" alt="Screenshot 2025-07-25 at 2 16 27 PM" src="https://github.com/user-attachments/assets/ea763be5-d3a7-46da-bf98-acf01a50d5c5" />
<img width="1849" height="1398" alt="Screenshot 2025-07-25 at 2 16 35 PM" src="https://github.com/user-attachments/assets/df73cea6-0d58-4638-b0da-697812f70e91" />
<img width="1849" height="1398" alt="Screenshot 2025-07-25 at 2 16 54 PM" src="https://github.com/user-attachments/assets/af333e7e-2915-4ee6-8e14-056b4e6f226e" />
